### PR TITLE
fix to avoid cached posts affect refresh

### DIFF
--- a/src/components/tabbedPosts/services/tabbedPostsFetch.ts
+++ b/src/components/tabbedPosts/services/tabbedPostsFetch.ts
@@ -132,7 +132,7 @@ export const loadPosts = async ({
         return {latestPosts}
       }else{
         const updatedPosts = getUpdatedPosts(
-          prevPosts,
+          startAuthor && startPermlink ? prevPosts:[],
           result,
           refreshing,
           tabMeta,


### PR DESCRIPTION
somehow the demo.com friends feed is ending up to empty list from server, while app was using chached... added a small fix to ignore cached data if refreshed data has no post returned by server... rare case, but covered anyways.