### PR TITLE
Youtube iFrame

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "react-native-version-number": "^0.3.5",
     "react-native-webview": "^11.2.1",
     "react-native-youtube": "^2.0.1",
+    "react-native-youtube-iframe": "^2.0.1",
     "react-navigation": "^4.0.10",
     "react-navigation-drawer": "^2.3.3",
     "react-navigation-redux-helpers": "^4.0.1",

--- a/src/components/postElements/body/view/youtubePlayer.tsx
+++ b/src/components/postElements/body/view/youtubePlayer.tsx
@@ -1,0 +1,53 @@
+import React, {useState} from 'react';
+import { View, StyleSheet, ActivityIndicator } from 'react-native';
+import YoutubeIframe from 'react-native-youtube-iframe';
+
+interface YoutubePlayerProps {
+    videoId:string
+}
+
+const YoutubePlayer = ({videoId}: YoutubePlayerProps) => {
+
+    const [shouldPlay, setShouldPlay] = useState(false);
+    const [loading, setLoading] = useState(true);
+
+    const _onReady = () => {
+        setLoading(false)
+        setShouldPlay(true);
+    }
+
+    const _onChangeState = (event:string) => {
+        setShouldPlay(!(event == 'paused' || event == 'ended'));
+    }
+
+    const _onError = () => {
+        setLoading(false)
+    }
+
+    return (
+        <View style={styles.container}>
+            
+            {videoId && 
+                <YoutubeIframe 
+                    height={250} 
+                    videoId={videoId} 
+                    onReady={_onReady} 
+                    play={shouldPlay} 
+                    onChangeState={_onChangeState} 
+                    onError={_onError}
+                />
+            }
+            {loading && <ActivityIndicator style={styles.activityIndicator}/>}
+        </View>
+  );
+};
+
+export default YoutubePlayer;
+
+const styles = StyleSheet.create({
+    container: {
+        paddingVertical:16,
+    },
+    activityIndicator: {
+        position:'absolute', alignItems:'center', justifyContent:'center', top:0, bottom:0, left:0, right:0}
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3619,7 +3619,7 @@ events@^1.1.0:
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
-events@^3.0.0:
+events@^3.0.0, events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -7691,6 +7691,13 @@ react-native-webview@^11.2.1:
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"
+
+react-native-youtube-iframe@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-youtube-iframe/-/react-native-youtube-iframe-2.0.1.tgz#19182bf95904e0cc5da4c6ea488a02551db9396d"
+  integrity sha512-DPu4nyHhfGs+bylgFRYuRjHlP0mg5Wjlm+KAPRhV68mUMuK1c3v2nXapuoia5GFkmtDwTrrMpIf5iG99QJoILg==
+  dependencies:
+    events "^3.2.0"
 
 react-native-youtube@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
integrated youtube iframe as action sheet. It does seem to work well across all devices.. 

Though on emulator it's only plays audio but that should not affect actual device as it is a know issue 
https://github.com/LonelyCpp/react-native-youtube-iframe/issues/29


### Known Issue
On android, when video is in fullscreen and user change device orientation, the app triggers a reset and gets stuck on loading screen. issue can be seen in video as well.
Any solution suggestion from your experience?

### Screenshots/Video
https://user-images.githubusercontent.com/6298342/117560096-44c7c500-b0a4-11eb-8fbb-89fdd77a3a63.mov
