### PR TITLE
auto install pods when yarn install is done

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "clear": "watchman watch-del-all && rm -rf $TMPDIR/react-native-packager-cache-* && rm -rf $TMPDIR/metro-bundler-cache-* && rm -rf node_modules/ && yarn && yarn start -- --reset-cache",
     "bump-patch": "npm version patch --no-git-tag-version",
     "bump-minor": "npm version minor --no-git-tag-version",
-    "bump-major": "npm version major --no-git-tag-version"
+    "bump-major": "npm version major --no-git-tag-version",
+    "postinstall": "cd ios && pod install"
   },
   "dependencies": {
     "@babel/runtime": "^7.5.5",


### PR DESCRIPTION
runs `pod install` every time packages are updated using `yarn`. simple script to take away hassle of doing pod install every time