### PR TITLE
NT - RN Push Notification Upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-native-modal-dropdown": "ecency/react-native-modal-dropdown",
     "react-native-modal-translucent": "^5.0.0",
     "react-native-navigation-bar-color": "^1.0.0",
-    "react-native-push-notification": "^3.5.1",
+    "react-native-push-notification": "^7.3.1",
     "react-native-qrcode-svg": "^6.0.3",
     "react-native-reanimated": "^1",
     "react-native-receive-sharing-intent": "ecency/react-native-receive-sharing-intent",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7577,12 +7577,10 @@ react-native-navigation-bar-color@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-navigation-bar-color/-/react-native-navigation-bar-color-1.0.0.tgz#04ff752a58049af93ceea9ccf266b8d3fbc6514a"
   integrity sha512-djBE0zSp+JT65VeUm4UpIpr9DA9SpE9YTLwDAcqkWfB9JI8l3djSx+SmrIYfc7dUs216Y6qo2dr0qR3+M5qbOQ==
 
-react-native-push-notification@^3.5.1:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/react-native-push-notification/-/react-native-push-notification-3.5.2.tgz#5f6226d12a00c25c15279325b57c5fbddd5b1c82"
-  integrity sha512-eh9l7WeL7Lxq17ntsafCrNQF6aW8XS6b7PG/s1Y8amAqpDt8GJ8hz125z566N1jsj3PDh9pfd4SjNS+tLaV47A==
-  dependencies:
-    "@react-native-community/push-notification-ios" "^1.2.0"
+react-native-push-notification@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-push-notification/-/react-native-push-notification-7.3.1.tgz#1495feacd25169b998446dcf7b448a197ae5dca0"
+  integrity sha512-5kSKPvDU23uZRmzgKTsGhbwGNvB2tidu1VnInBHP53ZD0VEPSBl5fbpuTfHH98ED+Gp1SCcT2/e6bJWkIspKvg==
 
 react-native-qrcode-svg@^6.0.3:
   version "6.1.1"


### PR DESCRIPTION
Upgraded RN push notification package to latest one

I seems there have been some breaking changes introduced to the notification system of android that was causing the crash... latest upgrade of RN push notification seems to fix the issue...

One thing I wanted to ask about the package itself, it seems it is only being used to cancel notifications and setting notification badge to 0... other than that it serve no purpose as notifications itself are being handled by messaging package from firebase, is this done knowingly... ?
![Screenshot 2021-05-22 at 7 43 57 PM](https://user-images.githubusercontent.com/6298342/119230715-e2a4a080-bb36-11eb-9acf-34aa619a9501.png
