### PR TITLE
NT - Tabs Reset

### DIFF
--- a/src/components/profile/profileView.js
+++ b/src/components/profile/profileView.js
@@ -219,13 +219,13 @@ class ProfileView extends PureComponent {
     return (
       <View style={styles.postTabBar}>
         <TabbedPosts
+          key={username + JSON.stringify(filterOptions)}
           filterOptions={filterOptions}
           filterOptionsValue={tabs}
           selectedOptionIndex={0}
           pageType={pageType}
           getFor="blog"
           feedUsername={username}
-          key={username}
           handleOnScroll={isSummaryOpen ? this._handleOnScroll : null}
           forceLoadPost={forceLoadPost}
           changeForceLoadPostState={changeForceLoadPostState}


### PR DESCRIPTION
Enabled tabs reset on tabs selection change

This is a crucial step for any custom tab bar, it also help android to adapt to updated tabs, otherwise tabs do no update on android side at all.

Fixes the comments/replies data duplicate issue on tabs change as well.