### PR TITLE
added support for heic image links in meta

### DIFF
--- a/src/utils/editor.js
+++ b/src/utils/editor.js
@@ -132,7 +132,7 @@ export const makeJsonMetadataForUpdate = (oldJson, meta, tags) => {
 export const extractMetadata = (body) => {
   const urlReg = /(\b(https?|ftp):\/\/[A-Z0-9+&@#/%?=~_|!:,.;-]*[-A-Z0-9+&@#/%=~_|])/gim;
   const userReg = /(^|\s)(@[a-z][-.a-z\d]+[a-z\d])/gim;
-  const imgReg = /(https?:\/\/.*\.(?:png|jpg|jpeg|gif))/gim;
+  const imgReg = /(https?:\/\/.*\.(?:png|jpg|jpeg|gif|heic))/gim;
 
   const out = {};
 


### PR DESCRIPTION
Backtracking image issue turned out to be indeed heic not being read as a legit image source. Have updated the regex to support heic. It's untested at the moment, waiting for me iPhone, 15 - 30 minutes.
