### PR TITLE
NT - Action Modal

### DIFF
--- a/src/components/actionModal/container/actionModalContainer.tsx
+++ b/src/components/actionModal/container/actionModalContainer.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef } from 'react';
-import { Alert, AlertButton, ButtonProps } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import {AlertButton, ButtonProps } from 'react-native';
 import { Source } from 'react-native-fast-image';
 import { useSelector, useDispatch } from 'react-redux';
 import { ActionModalView } from '..';
@@ -19,22 +19,23 @@ const ActionModalContainer = ({ navigation }) => {
   const dispatch = useDispatch();
   const actionModalRef = useRef<ActionModalRef>();
 
-  const actionModalVisible = useSelector(
-    (state) => state.ui.actionModalVisible,
-  );
-
-    const actionModalData:ActionModalData = useSelector(state => state.ui.actionModalData)
-
+  const actionModalVisible = useSelector((state) => state.ui.actionModalVisible);
+  const actionModalData:ActionModalData = useSelector(state => state.ui.actionModalData)
+  
+  const [modalToken, setModalToken] = useState(0);
 
   useEffect(() => {
-    if (actionModalVisible) {
+    if (actionModalVisible && actionModalVisible !== modalToken) {
         actionModalRef.current?.showModal();
+        setModalToken(actionModalVisible);
     }
   }, [actionModalVisible]);
 
 
   const _onClose = () => {
-    actionModalData.onClosed();
+    if(actionModalData.onClosed){
+      actionModalData.onClosed();
+    }
     dispatch(hideActionModal());
   };
 

--- a/src/components/actionModal/view/actionModalStyles.ts
+++ b/src/components/actionModal/view/actionModalStyles.ts
@@ -9,9 +9,14 @@ export default EStyleSheet.create({
         paddingBottom:8,
       },
 
-      sheetContent: {
+    sheetContent: {
         backgroundColor: '$primaryBackgroundColor',
-      },
+        position:'absolute',
+        bottom:0,
+        left:0, 
+        right:0,
+        zIndex:999
+    },
 
     container:{
         marginTop:16,

--- a/src/components/actionModal/view/actionModalView.tsx
+++ b/src/components/actionModal/view/actionModalView.tsx
@@ -66,7 +66,7 @@ const ActionModalView = ({onClose, data}: ActionModalViewProps, ref) => {
                 
             
             <View style={styles.actionPanel}>
-                {
+                {buttons ? (
                     buttons.map((props)=>(
                         <TextButton 
                             key={props.text}
@@ -79,6 +79,17 @@ const ActionModalView = ({onClose, data}: ActionModalViewProps, ref) => {
                             textStyle={styles.btnText}
                         />
                     ))
+                ):(
+                    <TextButton
+                        key='default'
+                        text='OK'
+                        onPress={()=>{
+                            sheetModalRef.current?.setModalVisible(false);
+                        }}   
+                        style={styles.button}
+                        textStyle={styles.btnText}               
+                    />
+                )
                 }
             </View>
         </View>

--- a/src/redux/actions/uiAction.ts
+++ b/src/redux/actions/uiAction.ts
@@ -1,4 +1,5 @@
-import { ButtonProps } from 'react-native';
+
+import { AlertButton } from 'react-native';
 import {
   TOAST_NOTIFICATION,
   UPDATE_ACTIVE_BOTTOM_TAB,
@@ -20,9 +21,9 @@ export const toastNotification = (payload:string) => ({
   type: TOAST_NOTIFICATION,
 });
 
-export const showActionModal = (title:string, body:string, buttons:ButtonProps[], headerImage:any, onClosed:()=>void) => ({
+export const showActionModal = (title:string, body?:string, buttons?:AlertButton[], headerImage?:any, onClosed?:()=>void) => ({
   payload: {
-    actionModalVisible: true,
+    actionModalVisible: new Date().getTime(),
     actionModalData: {
       title,
       body,


### PR DESCRIPTION
Skipped any functional change for now, made action modal to slightly more adaptive by making props optional and using token based visibility instead of boolean flag based.

**Task Findings For Reference**
A number of our modals use alert box and so far I have not come across a clean solutions to implement a global alert box as nested modals require child modal to be a part of parent modal, not suitable for our approach.

Other approach I was planning was to build a custom modal, but that again gets rendered below visible modal irrespective of zIndex..

The current custom alert/action modal is useable from outside a modal only...

It seems it is a know limitation of react native

reference: https://github.com/react-native-modal/react-native-modal#i-cant-show-multiple-modals-at-the-same-time