### PR TITLE
NT - Signup Failure

### DIFF
--- a/src/providers/ecency/ecency.js
+++ b/src/providers/ecency/ecency.js
@@ -546,8 +546,12 @@ export const getPostReblogs = (data) =>
     .then((resp) => resp.data)
     .catch((error) => bugsnag.notify(error));
 
-export const register = (data) =>
-  api
-    .post('/signup/account-create', data)
-    .then((resp) => resp.data)
-    .catch((error) => bugsnag.notify(error));
+export const register = async (data) => {
+  try {
+    const res = await api.post('/signup/account-create', data);
+    return res.data;
+  } catch (error) {
+    bugsnag.notify(error);
+    throw error;
+  }
+};


### PR DESCRIPTION
The issue itself seems like a backend problem, the server is consistently showing busy status while registering new user.

On the app side, no failure alert was being shown leaving user confused, have updated the the api implementation to throw error back to calling container so alert ban be shown
![Screenshot 2021-06-22 at 1 56 18 PM](https://user-images.githubusercontent.com/6298342/122897186-33403100-d363-11eb-9b8a-a20daee795ba.png)

