### PR TITLE
Nt/clearing draft

### DIFF
--- a/src/providers/ecency/ecency.ts
+++ b/src/providers/ecency/ecency.ts
@@ -45,7 +45,7 @@ export const getDrafts = async () => {
 /**
  * @params draftId
  */
-export const removeDraft = async (draftId:string) => {
+export const deleteDraft = async (draftId:string) => {
   try{
     const data = { id:draftId }
     const res = await ecencyApi.post(`/private-api/drafts-delete`, data);

--- a/src/screens/drafts/container/draftsContainer.js
+++ b/src/screens/drafts/container/draftsContainer.js
@@ -6,7 +6,7 @@ import { injectIntl } from 'react-intl';
 // Services and Actions
 import {
   getDrafts,
-  removeDraft,
+  deleteDraft,
   getSchedules,
   moveScheduledToDraft,
   deleteScheduledPost,
@@ -64,7 +64,7 @@ const DraftsContainer = ({ currentAccount, intl, navigation, dispatch }) => {
   };
 
   const _removeDraft = (id) => {
-    removeDraft(id)
+    deleteDraft(id)
       .then(() => {
         const newDrafts = [...drafts].filter((draft) => draft._id !== id);
         setDrafts(_sortData(newDrafts));

--- a/src/screens/editor/container/editorContainer.js
+++ b/src/screens/editor/container/editorContainer.js
@@ -569,15 +569,16 @@ class EditorContainer extends Component {
       pinCode,
       // isDefaultFooter,
     } = this.props;
-    const { rewardType, beneficiaries } = this.state;
+    const { rewardType, beneficiaries, isPostSending, draftId } = this.state;
+
+    if(isPostSending){
+      return;
+    }
 
     if (currentAccount) {
       this.setState({
         isPostSending: true,
       });
-
-      //save as draft before submitting post...
-      await this._saveDraftToDB(fields, true);
 
       const meta = extractMetadata(fields.body);
       const _tags = fields.tags.filter((tag) => tag && tag !== ' ');
@@ -643,8 +644,6 @@ class EditorContainer extends Component {
               currentAccount.name,
             );
 
-            //important access draftId here as it can change within routine
-            const { draftId } = this.state;
             if (draftId) {
               //remove draft from backend
               await deleteDraft(draftId);

--- a/src/screens/editor/container/editorContainer.js
+++ b/src/screens/editor/container/editorContainer.js
@@ -262,7 +262,6 @@ class EditorContainer extends Component {
       const drafts = await getDrafts(username);
       const idLessDraft = await getDraftPost(username);
 
-
       const loadRecentDraft = () => {
         //if no draft available means local draft is recent
         if (drafts.length == 0) {
@@ -278,10 +277,11 @@ class EditorContainer extends Component {
 
         //if unsaved local draft is more latest then remote draft, use that instead
         //if editor was opened from draft screens, this code will be skipped anyways.
-        if ( idLessDraft
-          && (idLessDraft.title !== '' || idLessDraft.tags !== '' || idLessDraft.body !== '')
-          && new Date(_draft.modified).getTime() < idLessDraft.timestamp
-          ) {
+        if (
+          idLessDraft &&
+          (idLessDraft.title !== '' || idLessDraft.tags !== '' || idLessDraft.body !== '') &&
+          new Date(_draft.modified).getTime() < idLessDraft.timestamp
+        ) {
           _getStorageDraftGeneral(false);
           return;
         }
@@ -293,8 +293,6 @@ class EditorContainer extends Component {
         });
         this._getStorageDraft(username, isReply, _draft);
       };
-
-
 
       if (drafts.length > 0 || (idLessDraft && idLessDraft.timestamp > 0)) {
         this.setState({

--- a/src/screens/editor/container/editorContainer.js
+++ b/src/screens/editor/container/editorContainer.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
-import { Alert, Keyboard } from 'react-native';
+import { Alert } from 'react-native';
 import ImagePicker from 'react-native-image-crop-picker';
 import get from 'lodash/get';
 import AsyncStorage from '@react-native-community/async-storage';
@@ -14,8 +14,7 @@ import {
   addDraft,
   updateDraft,
   getDrafts,
-  addSchedule,
-  deleteDraft,
+  addSchedule
 } from '../../../providers/ecency/ecency';
 import { toastNotification, setRcOffer } from '../../../redux/actions/uiAction';
 import {
@@ -569,7 +568,7 @@ class EditorContainer extends Component {
       pinCode,
       // isDefaultFooter,
     } = this.props;
-    const { rewardType, beneficiaries, isPostSending, draftId } = this.state;
+    const { rewardType, beneficiaries, isPostSending } = this.state;
 
     if (isPostSending) {
       return;
@@ -643,11 +642,6 @@ class EditorContainer extends Component {
               },
               currentAccount.name,
             );
-
-            if (draftId) {
-              //remove draft from backend
-              await deleteDraft(draftId);
-            }
 
             await AsyncStorage.setItem('temp-beneficiaries', '');
 
@@ -956,7 +950,7 @@ class EditorContainer extends Component {
 
   _setScheduledPost = (data) => {
     const { dispatch, intl, currentAccount, navigation } = this.props;
-    const { rewardType, beneficiaries, draftId } = this.state;
+    const { rewardType, beneficiaries } = this.state;
 
     const options = makeOptions({
       author: data.author,
@@ -993,10 +987,6 @@ class EditorContainer extends Component {
           },
           currentAccount.name,
         );
-        //delete draft from server
-        if (draftId) {
-          deleteDraft(draftId);
-        }
 
         setTimeout(() => {
           navigation.navigate({

--- a/src/screens/editor/container/editorContainer.js
+++ b/src/screens/editor/container/editorContainer.js
@@ -682,6 +682,10 @@ class EditorContainer extends Component {
     const { currentAccount, pinCode } = this.props;
     const { rewardType, beneficiaries } = this.state;
 
+    if(isPostSending){
+      return;
+    }
+
     if (currentAccount) {
       this.setState({
         isPostSending: true,
@@ -723,6 +727,11 @@ class EditorContainer extends Component {
   _submitEdit = async (fields) => {
     const { currentAccount, pinCode } = this.props;
     const { post, isEdit } = this.state;
+
+    if(isPostSending){
+      return;
+    }
+
     if (currentAccount) {
       this.setState({
         isPostSending: true,

--- a/src/screens/editor/container/editorContainer.js
+++ b/src/screens/editor/container/editorContainer.js
@@ -493,7 +493,7 @@ class EditorContainer extends Component {
           );
         }
 
-        if(!silent){
+        if (!silent) {
           dispatch(
             toastNotification(
               intl.formatMessage({
@@ -502,7 +502,6 @@ class EditorContainer extends Component {
             ),
           );
         }
-        
 
         //call fetch post to drafts screen
         this._navigationBackFetchDrafts();
@@ -556,8 +555,6 @@ class EditorContainer extends Component {
       setDraftPost(draftField, username);
     }
   };
-
-
 
   _submitPost = async (fields, scheduleDate) => {
     const {
@@ -618,7 +615,6 @@ class EditorContainer extends Component {
           jsonMeta,
         });
       } else {
-
         await postContent(
           currentAccount,
           pinCode,
@@ -643,14 +639,13 @@ class EditorContainer extends Component {
               currentAccount.name,
             );
 
-            
             //important access draftId here as it can change within routine
             const { draftId } = this.state;
-            if(draftId){
+            if (draftId) {
               //remove draft from backend
               await deleteDraft(draftId);
             }
-            
+
             await AsyncStorage.setItem('temp-beneficiaries', '');
 
             dispatch(
@@ -679,9 +674,6 @@ class EditorContainer extends Component {
       }
     }
   };
-
-
-
 
   _submitReply = async (fields) => {
     const { currentAccount, pinCode } = this.props;
@@ -990,10 +982,10 @@ class EditorContainer extends Component {
           currentAccount.name,
         );
         //delete draft from server
-        if(draftId){
-          deleteDraft(draftId)
+        if (draftId) {
+          deleteDraft(draftId);
         }
-        
+
         setTimeout(() => {
           navigation.navigate({
             routeName: ROUTES.SCREENS.DRAFTS,

--- a/src/screens/editor/container/editorContainer.js
+++ b/src/screens/editor/container/editorContainer.js
@@ -262,6 +262,7 @@ class EditorContainer extends Component {
       const drafts = await getDrafts(username);
       const idLessDraft = await getDraftPost(username);
 
+
       const loadRecentDraft = () => {
         //if no draft available means local draft is recent
         if (drafts.length == 0) {
@@ -277,7 +278,10 @@ class EditorContainer extends Component {
 
         //if unsaved local draft is more latest then remote draft, use that instead
         //if editor was opened from draft screens, this code will be skipped anyways.
-        if (idLessDraft && new Date(_draft.modified).getTime() < idLessDraft.timestamp) {
+        if ( idLessDraft
+          && (idLessDraft.title !== '' || idLessDraft.tags !== '' || idLessDraft.body !== '')
+          && new Date(_draft.modified).getTime() < idLessDraft.timestamp
+          ) {
           _getStorageDraftGeneral(false);
           return;
         }
@@ -289,6 +293,8 @@ class EditorContainer extends Component {
         });
         this._getStorageDraft(username, isReply, _draft);
       };
+
+
 
       if (drafts.length > 0 || (idLessDraft && idLessDraft.timestamp > 0)) {
         this.setState({

--- a/src/screens/editor/container/editorContainer.js
+++ b/src/screens/editor/container/editorContainer.js
@@ -571,7 +571,7 @@ class EditorContainer extends Component {
     } = this.props;
     const { rewardType, beneficiaries, isPostSending, draftId } = this.state;
 
-    if(isPostSending){
+    if (isPostSending) {
       return;
     }
 
@@ -682,7 +682,7 @@ class EditorContainer extends Component {
     const { currentAccount, pinCode } = this.props;
     const { rewardType, beneficiaries } = this.state;
 
-    if(isPostSending){
+    if (isPostSending) {
       return;
     }
 
@@ -728,7 +728,7 @@ class EditorContainer extends Component {
     const { currentAccount, pinCode } = this.props;
     const { post, isEdit } = this.state;
 
-    if(isPostSending){
+    if (isPostSending) {
       return;
     }
 


### PR DESCRIPTION
Updated post submit flow.

1. While publishing a post, on successful response the draft is removed from ecency server if available
2. Similarly while scheduling, the associated draft is deleted on success
3. The recent draft logic is updated as it was causing issues after publish post draft delete
4. Added isPublishing flag to avoid possible publish duplication, though it may not be the reason for the problem shared by user, but should add some extra redundancy.
