### PR TITLE
fixed default vote value issue

### DIFF
--- a/src/components/upvote/view/upvoteView.tsx
+++ b/src/components/upvote/view/upvoteView.tsx
@@ -87,13 +87,14 @@ const UpvoteView = ({
 
   
   useEffect(() => {
-    setSliderValue(
-      (isVoted || isDownVoted) 
-      ? 1 
-      : upvotePercent <= 1
-        ? upvotePercent 
-        : 1
-    )
+    const value = (isVoted || isDownVoted) 
+    ? 1 
+    : upvotePercent <= 1
+      ? upvotePercent 
+      : 1;
+
+    setSliderValue(value);
+    _calculateEstimatedAmount(value);
   }, [upvotePercent])
 
 


### PR DESCRIPTION
Essentially initial estimation was being done before setting default saved slider value. Now it's happening in the same hook
