### PR TITLE
NT - Community Tag

### DIFF
--- a/src/components/postElements/headerDescription/view/postHeaderDescription.js
+++ b/src/components/postElements/headerDescription/view/postHeaderDescription.js
@@ -89,6 +89,16 @@ class PostHeaderDescription extends PureComponent {
             </View>
           </View>
           <View style={styles.rightContainer}>
+            {content && (
+              <TouchableOpacity>
+                <Tag
+                  isPostCardTag={!isPromoted}
+                  isPin
+                  value={content.category}
+                  communityTitle={content.community_title}
+                />
+              </TouchableOpacity>
+            )}
             {!!tag && (
               <TouchableOpacity onPress={() => tagOnPress && tagOnPress()}>
                 <Tag isPostCardTag={!isPromoted} isPin value={tag} />

--- a/src/components/postView/view/postDisplayView.js
+++ b/src/components/postView/view/postDisplayView.js
@@ -221,7 +221,6 @@ const PostDisplayView = ({
                 name={author || post.author}
                 currentAccountUsername={name}
                 reputation={post.author_reputation}
-                content={post}
                 size={36}
               />
               <PostBody body={post.body} onLoadEnd={_handleOnPostBodyLoad} />


### PR DESCRIPTION
Put back community tag in feed, kept removed from post details

### Screenshots/Video
![Screenshot 2021-07-24 at 8 33 29 PM](https://user-images.githubusercontent.com/6298342/126873440-94ec9bd6-fb47-4760-a4a0-a332a2b33a94.png)


**Suggestion**
Regarding community tag of post details...
If we want to show community tag in post header, may be we should remove community tag from list of tags below, this way we will not have double entries while creating a distinction between regular tags and community.
![Screenshot 2021-07-24 at 8 33 51 PM](https://user-images.githubusercontent.com/6298342/126873456-4619ab6d-4f47-47fa-94ba-21665fb743cd.png)

