### PR TITLE
NT - Startup Crash

### DIFF
--- a/src/components/tabbedPosts/view/listEmptyView.tsx
+++ b/src/components/tabbedPosts/view/listEmptyView.tsx
@@ -59,17 +59,19 @@ const TabEmptyView = ({
 
 
   useEffect(() => {
-    if (!leaderboard.loading) {
-      if (!leaderboard.error && leaderboard.data.length > 0) {
-        _formatRecommendedUsers(leaderboard.data);
+    const {loading, error, data} = leaderboard;
+    if (!loading) {
+      if (!error && data && data.length > 0) {
+        _formatRecommendedUsers(data);
       }
     }
   }, [leaderboard]);
 
   useEffect(() => {
-    if (!communities.loading) {
-      if (!communities.error && communities.data?.length > 0) {
-        _formatRecommendedCommunities(communities.data);
+    const {loading, error, data} = communities;
+    if (!loading) {
+      if (!error && data && data?.length > 0) {
+        _formatRecommendedCommunities(data);
       }
     }
   }, [communities]);

--- a/src/redux/reducers/communitiesReducer.js
+++ b/src/redux/reducers/communitiesReducer.js
@@ -69,7 +69,7 @@ export default function (state = initialState, action) {
       return {
         ...state,
         communities: {
-          data: action.payload,
+          data: action.payload || [],
           loading: false,
           error: false,
         },
@@ -96,7 +96,7 @@ export default function (state = initialState, action) {
       return {
         ...state,
         subscribedCommunities: {
-          data: action.payload,
+          data: action.payload || [],
           loading: false,
           error: false,
         },


### PR DESCRIPTION
Added null checks for communities leaderboard data

It is potentially the same bug annoying users every time the login as app started crashing on one of my test devices out no where. Let's hope this fixes that for users as well.