### PR TITLE
updated api path for code exclude list

### DIFF
--- a/src/config/ecencyApi.ts
+++ b/src/config/ecencyApi.ts
@@ -18,7 +18,7 @@ api.interceptors.request.use((request) => {
   console.log('Starting ecency Request', request);
   
   //skip code addition is register and token refresh endpoint is triggered
-  if(request.url === '/signup/account-create' 
+  if(request.url === '/private-api/account-create' 
     || request.url === '/auth-api/hs-token-refresh' 
     || request.url === '/private-api/promoted-entries'
     || request.url.startsWith('private-api/leaderboard')


### PR DESCRIPTION
create-account endpoint was not being being filtered from access code insertion because of api path typo.
It was not blocking signup but it was better to clean up.
