### PR TITLE
Nt - Scrolling Comment

### DIFF
--- a/src/components/postView/view/postDisplayStyles.js
+++ b/src/components/postView/view/postDisplayStyles.js
@@ -1,3 +1,4 @@
+import { Dimensions } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 
 export default EStyleSheet.create({
@@ -25,6 +26,9 @@ export default EStyleSheet.create({
     height: '$deviceHeight',
     backgroundColor: '$primaryBackgroundColor',
     marginBottom: 40,
+  },
+  scrollContent: {
+    minHeight: Dimensions.get('window').height,
   },
   footer: {
     flexDirection: 'column',

--- a/src/components/postView/view/postDisplayView.js
+++ b/src/components/postView/view/postDisplayView.js
@@ -204,6 +204,7 @@ const PostDisplayView = ({
     <View style={styles.container}>
       <ScrollView
         style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
         onScroll={(event) => _handleOnScroll(event)}
         scrollEventThrottle={16}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}


### PR DESCRIPTION
setting post display scroll to have min height equals window

android web view do not support scrollEnabled property and when scroll viewport is less than scrollable height, the webview was letting the content to be scroll, this was happening for both comment and body.

now, since height will always be scrollable, content of webview is set to not scrollable.

### Screenshots/Video
https://user-images.githubusercontent.com/6298342/129716394-ad683887-7a69-48c3-be4f-d5d1c5d0ace4.mov




