### PR TITLE
clipping @ and # from start of search query

### DIFF
--- a/src/screens/searchResult/screen/searchResultScreen.tsx
+++ b/src/screens/searchResult/screen/searchResultScreen.tsx
@@ -37,6 +37,10 @@ const SearchResultScreen = ({ navigation }) => {
     setSearchValue(value);
   }, 1000);
 
+  let clippedSearchValue = searchValue.startsWith('#') || searchValue.startsWith('@') 
+    ? searchValue.substring(1) 
+    : searchValue
+
   return (
     <View style={styles.container}>
       <SearchInput
@@ -57,25 +61,25 @@ const SearchResultScreen = ({ navigation }) => {
           tabLabel={intl.formatMessage({ id: 'search_result.best.title' })}
           style={styles.tabbarItem}
         >
-          <PostsResults searchValue={searchValue} />
+          <PostsResults searchValue={clippedSearchValue} />
         </View>
         <View
           tabLabel={intl.formatMessage({ id: 'search_result.people.title' })}
           style={styles.tabbarItem}
         >
-          <PeopleResults searchValue={searchValue} />
+          <PeopleResults searchValue={clippedSearchValue} />
         </View>
         <View
           tabLabel={intl.formatMessage({ id: 'search_result.topics.title' })}
           style={styles.tabbarItem}
         >
-          <TopicsResults searchValue={searchValue} />
+          <TopicsResults searchValue={clippedSearchValue} />
         </View>
         <View
           tabLabel={intl.formatMessage({ id: 'search_result.communities.title' })}
           style={styles.tabbarItem}
         >
-          <Communities searchValue={searchValue} />
+          <Communities searchValue={clippedSearchValue} />
         </View>
       </ScrollableTabView>
     </View>


### PR DESCRIPTION
### What does this PR?
the search result screen clips prefix (@, #) from query before injected that value to search tabs, it does not change the apparent query for user by keeping the actual input value to state,  but only inject a server readable query relevant components


### Screenshots/Video
https://user-images.githubusercontent.com/6298342/129911618-b818f94c-9bd0-48eb-9c3e-491b9ae4c6d7.mov



