### PR TITLE
Nt - JCenter Removal

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,8 +23,10 @@ buildscript {
         firebaseVersion = "17.3.4"
     }
     repositories {
+        mavenCentral()
         google()
-        jcenter()
+
+        
     }
     dependencies {
         classpath('com.android.tools.build:gradle:4.1.0')
@@ -37,6 +39,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
@@ -50,9 +53,22 @@ allprojects {
         maven { url 'https://maven.google.com' }
 
         google()
-        jcenter()
         maven { url "https://www.jitpack.io" }
-        // mavenCentral()
+
+
+        //TODO: remove when replacement for selective groups is available
+        //the jcenter will be accessible as read-only indefinitely so we should be
+        //good for now with these selective packages as they are not available off of 
+        //jCenter
+        jcenter() {
+            content {
+                // these groups only available in jcenter otherwise we don't want to rely on jcenter.
+                includeGroup("com.facebook.yoga")
+                includeGroup("com.facebook.fbjni")
+                includeGroup("com.henninghall.android")
+                includeGroup("org.matomo.sdk")
+            }
+        }
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,8 +49,6 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
-        // react-native-image-crop-picker
-        maven { url 'https://maven.google.com' }
 
         google()
         maven { url "https://www.jitpack.io" }


### PR DESCRIPTION
Shifted repo to mavenCentral with exception of few selective group
Remove when replacement for selective groups is available the jcenter will be accessible as read-only indefinitely so we should be good for now with these selective packages as they are not available off of jCenter

Selective groups:
            includeGroup("com.facebook.yoga")
            includeGroup("com.facebook.fbjni")
            includeGroup("com.henninghall.android")
            includeGroup("org.matomo.sdk")


However since they are now read-only means no updates will be received by jCenter... we should check back at some point in future if we can get rid of these groups as well.

App does build successfully in my tests with this setup

Let me know your thoughts.