### PR TITLE
freeing up link state value

### DIFF
--- a/src/components/postElements/body/view/commentBodyView.tsx
+++ b/src/components/postElements/body/view/commentBodyView.tsx
@@ -100,9 +100,8 @@ const CommentBody = ({
       //save to local
       _saveImage(selectedImage);
     }
-    if (ind === 3) {
-      setSelectedImage(null);
-    }
+
+    setSelectedImage(null);
   };
 
   const handleLinkPress = (ind) => {
@@ -136,9 +135,9 @@ const CommentBody = ({
         );
       });
     }
-    if (ind === 2) {
-      setSelectedLink(null);
-    }
+    
+    setSelectedLink(null);
+    
   };
 
   const _handleTagPress = (tag) => {

--- a/src/components/postElements/body/view/postBodyView.js
+++ b/src/components/postElements/body/view/postBodyView.js
@@ -164,11 +164,8 @@ const PostBody = ({
       //save to local
       _saveImage(selectedImage);
     }
-    if (ind === 3) {
-      //cancel
-      setPostImages([]);
-      setSelectedImage(null);
-    }
+
+    setSelectedImage(null);
   };
 
   const handleLinkPress = (ind) => {
@@ -202,10 +199,8 @@ const PostBody = ({
         );
       });
     }
-    if (ind === 2) {
-      //cancel
-      setSelectedLink(null);
-    }
+
+    setSelectedLink(null);
   };
 
   const _handleTagPress = (tag) => {


### PR DESCRIPTION
setting link value to null to free up for next click once actionsheet callback has processed link irrespective of option selected.

To test, tap on same link or image back to back.

