### PR TITLE
Nt - Permlink Duplication

### DIFF
--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -601,7 +601,7 @@ class EditorContainer extends Component {
         dublicatePost = null;
       }
 
-      if (dublicatePost && dublicatePost.id) {
+      if (dublicatePost && (dublicatePost.permlink === permlink)) {
         permlink = generatePermlink(fields.title, true);
       }
 


### PR DESCRIPTION
Comparing post permlink for duplication instead of checking for id
The id is undefined in the post data returned, checking for permlink seems like a more reliable.

### Steps to reproduce
To test, write new post with title matching an old post in you account... In demo.com I used `Wallet` as title that was title of post from 3 months back and it failed with similar error faced by Melinda

<img width="302" alt="Screenshot 2021-09-10 at 9 19 39 PM" src="https://user-images.githubusercontent.com/6298342/132886929-86acc991-f3d4-4c6a-b24f-85688fb83648.png">

But with these changes I was able to regenerate permlink to random id attached at the end.