### PR TITLE
added 1 second debounce time for username input

### DIFF
--- a/src/screens/login/screen/loginScreen.js
+++ b/src/screens/login/screen/loginScreen.js
@@ -3,6 +3,7 @@ import { View, StatusBar, Platform } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import ScrollableTabView from 'react-native-scrollable-tab-view';
 import { injectIntl } from 'react-intl';
+import { debounce } from 'lodash';
 
 // Actions
 import HiveSigner from '../../steem-connect/hiveSigner';
@@ -112,7 +113,7 @@ class LoginScreen extends PureComponent {
                 leftIconName="close"
                 iconType="MaterialCommunityIcons"
                 isValid={isUsernameValid}
-                onChange={(value) => this._handleUsernameChange(value)}
+                onChange={debounce(this._handleUsernameChange, 1000)}
                 placeholder={intl.formatMessage({
                   id: 'login.username',
                 })}


### PR DESCRIPTION
It seems sometimes if username is now found by getAccountsByUsername, it takes a few milliseconds more than coming call with existing username, that delayed fired callback was causing the bug as faced while typing username.

After adding debouce, test the flow multiple many time for redundancy

### Screenshots/Video
https://user-images.githubusercontent.com/6298342/134784665-6e3d0c92-6dd7-4812-b1f3-90592b98d9a4.mov
