### PR TITLE
adjusting json_metadata tags to not be string

### DIFF
--- a/src/components/postView/view/postDisplayView.js
+++ b/src/components/postView/view/postDisplayView.js
@@ -62,7 +62,7 @@ const PostDisplayView = ({
   useEffect(() => {
     if (post) {
       const _tags = get(post.json_metadata, 'tags', []);
-      if (post.category && _tags[0] !== post.category && Array.isArray(tags)) {
+      if (post.category && _tags[0] !== post.category && Array.isArray(_tags)) {
         _tags.splice(0, 0, post.category);
       }
       setTags(_tags);

--- a/src/utils/postParser.tsx
+++ b/src/utils/postParser.tsx
@@ -40,12 +40,7 @@ export const parsePost = (post, currentUserName, isPromoted, isList = false) => 
   }
 
   //adjust tags type as it can be string sometimes;
-  if(post.json_metadata){
-    const _tags = get(post.json_metadata, 'tags', []);
-    if(typeof _tags === 'string'){
-      post.json_metadata.tags = [_tags];
-    }
-  }
+  post = parseTags(post);
 
 
   //extract cover image and thumbnail from post body
@@ -154,12 +149,8 @@ export const parseComment = (comment:any) => {
   }
 
   //adjust tags type as it can be string sometimes;
-  if(comment.json_metadata){
-    const _tags = get(comment.json_metadata, 'tags', []);
-    if(typeof _tags === 'string'){
-      comment.json_metadata.tags = [_tags];
-    }
-  }
+  comment = parseTags(comment);
+  
 
   //calculate and set total_payout to show to user.
   const totalPayout =
@@ -222,3 +213,20 @@ export const parseActiveVotes = (post) => {
 
   return post.active_votes;
 };
+
+
+const parseTags = (post:any) => {
+  if(post.json_metadata){
+    let _tags =  get(post.json_metadata, 'tags', []);
+    if(typeof _tags === 'string'){
+      let separator = ' ';
+      if(_tags.indexOf(', ') > -1){
+        separator = ', ';
+      }else if(_tags.indexOf(',') > -1){
+        separator = ',';
+      }
+      post.json_metadata.tags = _tags.split(separator)
+    }
+  }
+  return post;
+}

--- a/src/utils/postParser.tsx
+++ b/src/utils/postParser.tsx
@@ -39,6 +39,15 @@ export const parsePost = (post, currentUserName, isPromoted, isList = false) => 
     }
   }
 
+  //adjust tags type as it can be string sometimes;
+  if(post.json_metadata){
+    const _tags = get(post.json_metadata, 'tags', []);
+    if(typeof _tags === 'string'){
+      post.json_metadata.tags = [_tags];
+    }
+  }
+
+
   //extract cover image and thumbnail from post body
   post.image = catchPostImage(post, 600, 500, webp ? 'webp' : 'match');
   post.thumbnail = catchPostImage(post, 10, 7, webp ? 'webp' : 'match');
@@ -143,6 +152,15 @@ export const parseComment = (comment:any) => {
       comment.json_metadata = {};
     }
   }
+
+  //adjust tags type as it can be string sometimes;
+  if(comment.json_metadata){
+    const _tags = get(comment.json_metadata, 'tags', []);
+    if(typeof _tags === 'string'){
+      comment.json_metadata.tags = [_tags];
+    }
+  }
+
   //calculate and set total_payout to show to user.
   const totalPayout =
     parseAsset(comment.pending_payout_value).amount +


### PR DESCRIPTION
### What does this PR?
It seems that some hive app or some logic is setting tags to be a string if there is just one tag...that was causing the crash of frontend, though there was also one bug of array check not working as expected but  now the issue has been fixed in the root or postParser.

### Screenshots/Video
NOTE: notification was rerouted to troublemaking comment for testing purpose, the test code is removed from PR.
https://user-images.githubusercontent.com/6298342/135722885-3e140624-b9f7-4708-830b-aead0cc5f0cd.mov


