### PR TITLE
Nt/follow btn

### DIFF
--- a/src/components/organisms/quickProfileModal/children/actionPanel.tsx
+++ b/src/components/organisms/quickProfileModal/children/actionPanel.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { IconButton } from '../../..';
-import { useAppSelector } from '../../../../hooks';
 import styles from './quickProfileStyles';
 
 interface ActionPanelProps {
     isFollowing:boolean,
     isFavourite:boolean,
     isMuted:boolean,
+    isLoading:boolean,
     onFollowPress:()=>void,
     onFavouritePress:()=>void
 }
@@ -17,6 +17,7 @@ export const ActionPanel = ({
   isFollowing, 
   isFavourite, 
   isMuted,
+  isLoading,
   onFavouritePress, 
   onFollowPress
 }: ActionPanelProps) => {
@@ -47,7 +48,7 @@ export const ActionPanel = ({
               name={followIcon}
               size={20}
               color={EStyleSheet.value('$iconColor')}
-              disabled={isFollowing}
+              disabled={isFollowing || isLoading}
               onPress={onFollowPress}
             />
           ) 

--- a/src/components/organisms/quickProfileModal/children/quickProfileContent.tsx
+++ b/src/components/organisms/quickProfileModal/children/quickProfileContent.tsx
@@ -261,11 +261,12 @@ export const QuickProfileContent = ({
             />
             {isLoggedIn && (
                 <ActionPanel 
-                isFollowing={isFollowing}
-                isFavourite={isFavourite}
-                isMuted={isMuted}
-                onFavouritePress={_onFavouritePress}
-                onFollowPress={_onFollowPress}
+                    isFollowing={isFollowing}
+                    isFavourite={isFavourite}
+                    isMuted={isMuted}
+                    isLoading={isLoading}
+                    onFavouritePress={_onFavouritePress}
+                    onFollowPress={_onFollowPress}
                 />
             )}
            

--- a/src/components/profileSummary/view/profileSummaryView.js
+++ b/src/components/profileSummary/view/profileSummaryView.js
@@ -112,6 +112,7 @@ class ProfileSummaryView extends PureComponent {
       percentVP,
       username,
     } = this.props;
+
     let dropdownOptions = [];
     const votingPowerHoursText = hoursVP && `• Full in ${hoursVP} hours`;
     const votingPowerText = `Voting power: ${percentVP}% ${votingPowerHoursText || ''}`;
@@ -236,6 +237,7 @@ class ProfileSummaryView extends PureComponent {
               <TouchableOpacity
                 style={styles.followActionWrapper}
                 onPress={() => handleFollowUnfollowUser(!isFollowing)}
+                disabled={isProfileLoading}
               >
                 <Text style={styles.actionText}>{followButtonText}</Text>
               </TouchableOpacity>

--- a/src/containers/profileContainer.js
+++ b/src/containers/profileContainer.js
@@ -192,14 +192,19 @@ class ProfileContainer extends Component {
         dispatch(
           toastNotification(
             intl.formatMessage({
-              id: isFollowing ? 'alert.success_unfollow' : 'alert.success_follow',
+              id: isFollowAction ? 'alert.success_follow' : 'alert.success_unfollow',
             }),
           ),
         );
-        this._profileActionDone();
+
+        this.setState({
+          isFollowing: isFollowAction,
+        });
+
+        this._profileActionDone({ shouldFetchProfile: false });
       })
       .catch((err) => {
-        this._profileActionDone(err);
+        this._profileActionDone({ error: err });
       });
   };
 
@@ -247,11 +252,11 @@ class ProfileContainer extends Component {
         );
       })
       .catch((err) => {
-        this._profileActionDone(err);
+        this._profileActionDone({ error: err });
       });
   };
 
-  _profileActionDone = (error = null) => {
+  _profileActionDone = ({ error = null, shouldFetchProfile = true }) => {
     const { username } = this.state;
     const { intl, dispatch } = this.props;
 
@@ -277,7 +282,7 @@ class ProfileContainer extends Component {
             ),
         );
       }
-    } else {
+    } else if (shouldFetchProfile) {
       this._fetchProfile(username, true);
     }
   };
@@ -338,7 +343,7 @@ class ProfileContainer extends Component {
       user = await getUser(username, isOwnProfile);
       this._fetchProfile(username);
     } catch (error) {
-      this._profileActionDone(error);
+      this._profileActionDone({ error });
     }
 
     this.setState((prevState) => ({


### PR DESCRIPTION
### What does this PR?
1. disabling follow button while action in loading state for both profile screen and modal
2. avoid fetching profile after follow unfollow action as previous transaction value overwrite the new, and double profile fetch do not always yield the right result, instead rely on cached state.

### Current issue
in video will see a state where modal shows user is following while profile show user is not following, that is because of transaction delay and the fact cache is only limited to state of profile screen.
Ideally user may not be annoyed as status should update in a second or two but if we want fix that we can maintain follow state at redux level, but for now major bug is resolved. Let me know your thoughts.

### Screenshots/Video
https://user-images.githubusercontent.com/6298342/143588916-467545d2-5bf4-4c96-8434-d947f5aeadbd.mov


