### PR TITLE
Nt/feed refresh

### DIFF
--- a/src/components/tabbedPosts/services/tabbedPostsFetch.ts
+++ b/src/components/tabbedPosts/services/tabbedPostsFetch.ts
@@ -32,6 +32,7 @@ export const loadPosts = async ({
 
     const {isLoading, startPermlink, startAuthor} = tabMeta;
     
+    //reject update if already loading
     if (
         isLoading ||
       !isConnected ||
@@ -41,6 +42,7 @@ export const loadPosts = async ({
       return;
     }
 
+    //reject update if no connection
     if (!isConnected && (refreshing || isLoading)) {
       setTabMeta({
         ...tabMeta,


### PR DESCRIPTION
### What does this PR?
fixes feed refresh issue if primary posts dataset is same, now upon refresh or launch, app discards previous state even feed data contains same posts.
