### PR TITLE
opening witness link externally as done on ecency web version

### DIFF
--- a/src/components/postHtmlRenderer/linkDataParser.ts
+++ b/src/components/postHtmlRenderer/linkDataParser.ts
@@ -73,7 +73,8 @@ export const parseLinkData = (tnode:TNode):LinkData => {
 
   if (tnode.classes.includes('markdown-witnesses-link')) {
    return {
-      type: 'markdown-witnesses-link'
+      type: 'markdown-witnesses-link',
+      href: tnode.attributes['data-href']
     };
 
   }

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -90,8 +90,9 @@ export const PostHtmlRenderer = memo(({
           break;
 
         //unused cases
-        // case 'markdown-witnesses-link':
-        //   break;
+        case 'markdown-witnesses-link':
+          setSelectedLink(href);
+          break;
         // case 'markdown-proposal-link':
         //   break;
         default:


### PR DESCRIPTION
### What does this PR?

the witness link was being ignore previously for some reason, I have enabled it to open witness link externally.

Let me know if it was being ignore on purpose or by mistake, in any case, it was giving a bad UX so now at-least link open externally just like website.

Let me know if we should handle in some other way.


### Screenshots/Video
BEFORE/AFTER COMPARISON

https://user-images.githubusercontent.com/6298342/146431236-07119be2-362b-4d03-ac62-4504136a2662.mov


