### PR TITLE
image size fix

### DIFF
--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from "react";
+import { Image } from "react-native";
+import EStyleSheet from "react-native-extended-stylesheet";
+import FastImage from "react-native-fast-image";
+import { TouchableWithoutFeedback } from "react-native-gesture-handler";
+
+
+
+  export const AutoHeightImage = ({
+    contentWidth, 
+    imgUrl, 
+    isAnchored, 
+    onPress
+  }:{
+    contentWidth:number, 
+    imgUrl:string,
+    isAnchored:boolean,
+    onPress:()=>void,
+  }) => {
+
+
+    const [imgWidth, setImgWidth] = useState(contentWidth);
+    const [imgHeight, setImgHeight] = useState(imgWidth * (9/16))
+    const [onLoadCalled, setOnLoadCalled] = useState(false);
+
+    useEffect(() => {
+      _fetchImageBounds();
+    }, [])
+
+    const _fetchImageBounds = () => {
+        Image.getSize(imgUrl, (width, height)=>{
+          const newWidth = width < contentWidth ? width : contentWidth;
+          const newHeight = (height / width) * newWidth;
+          setImgHeight(newHeight);
+          setImgWidth(newWidth);
+        })
+    }
+
+    const imgStyle = {
+      width:imgWidth, 
+      height:imgHeight, 
+      backgroundColor: onLoadCalled ? 'transparent' : EStyleSheet.value('$primaryGray')
+    }
+
+    const _onLoad = () => {
+      setOnLoadCalled(true);
+    }
+
+    return (
+      <TouchableWithoutFeedback onPress={onPress} disabled={!isAnchored}>
+        <FastImage 
+          style={imgStyle}
+          source={{uri:imgUrl}}
+          resizeMode={FastImage.resizeMode.contain}
+          onLoad={_onLoad}
+        />
+      </TouchableWithoutFeedback>
+      
+    )
+  }

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -1,11 +1,9 @@
-import React, { memo, useState } from "react";
+import React, { memo } from "react";
 import RenderHTML, { CustomRendererProps, Element, TNode } from "react-native-render-html";
 import styles from "./postHtmlRendererStyles";
 import { LinkData, parseLinkData } from "./linkDataParser";
 import VideoThumb from "./videoThumb";
-import FastImage, { OnLoadEvent } from "react-native-fast-image";
-import { TouchableOpacity, TouchableWithoutFeedback } from "react-native-gesture-handler";
-import EStyleSheet from "react-native-extended-stylesheet";
+import { AutoHeightImage } from "../autoHeightImage/autoHeightImage";
 
 
 interface PostHtmlRendererProps {
@@ -214,47 +212,3 @@ export const PostHtmlRenderer = memo(({
 
 
 
-
-  const AutoHeightImage = ({
-    contentWidth, 
-    imgUrl, 
-    isAnchored, 
-    onPress
-  }:{
-    contentWidth:number, 
-    imgUrl:string,
-    isAnchored:boolean,
-    onPress:()=>void,
-  }) => {
-
-    const [imgWidth, setImgWidth] = useState(contentWidth);
-    const [imgHeight, setImgHeight] = useState(imgWidth * (9/16))
-    const [onLoadCalled, setOnLoadCalled] = useState(false);
-
-    const imgStyle = {
-      width:imgWidth, 
-      height:imgHeight, 
-      backgroundColor: onLoadCalled ? 'transparent' : EStyleSheet.value('$primaryGray')
-    }
-
-    const _onLoad = (evt:OnLoadEvent) => {
-      const {width, height} = evt.nativeEvent;
-      const newWidth = width < contentWidth ? width : contentWidth;
-      const newHeight = (height / width) * newWidth;
-      setImgHeight(newHeight);
-      setImgWidth(newWidth);
-      setOnLoadCalled(true);
-    }
-
-    return (
-      <TouchableWithoutFeedback onPress={onPress} disabled={!isAnchored}>
-        <FastImage 
-          style={imgStyle}
-          source={{uri:imgUrl}}
-          resizeMode={FastImage.resizeMode.contain}
-          onLoad={_onLoad}
-        />
-      </TouchableWithoutFeedback>
-      
-    )
-  }


### PR DESCRIPTION
### What does this PR?
using external image ratio calculator, apparently on android FastImage was returning wrong image sizes, now we are using getSize external method from Image to set image ratio... 

Though the content rendering have become more smooth yet now we are making double the amount of network calls for single image under the hood. We can further try maintaining a long cache of image ratios to avoid that, yet we should first test the current implementation and discuss.

### Screenshots/Video

https://user-images.githubusercontent.com/6298342/146679776-b74f900e-9262-4b33-9111-184dfedff5d0.mov


