### PR TITLE
updated wallet tab label to have 2 decimal figures

### DIFF
--- a/src/components/profile/profileView.js
+++ b/src/components/profile/profileView.js
@@ -181,7 +181,7 @@ class ProfileView extends PureComponent {
         key="profile.wallet"
         tabLabel={
           estimatedWalletValue
-            ? `${currencySymbol} ${(estimatedWalletValue * currencyRate).toFixed()}`
+            ? `${currencySymbol} ${(estimatedWalletValue * currencyRate).toFixed(2)}`
             : null
         }
       >


### PR DESCRIPTION
The only difference in estimated wallet values I could find is in the wallet tab label as it was rounding the value to have to decimal point, now it has 2 for better close estimation. 

Please let me know if this was the wrong estimated value you were pointing to in trello card.

### Screenshots/Video
<img width="614" alt="Screenshot 2021-12-26 at 2 22 56 PM" src="https://user-images.githubusercontent.com/6298342/147404288-6ae4a12e-f195-4428-96bc-26d9f1281095.png">

