### PR TITLE
fixed upvote popover alignment issues in rtl layout

### DIFF
--- a/src/components/upvote/view/upvoteStyles.js
+++ b/src/components/upvote/view/upvoteStyles.js
@@ -86,10 +86,12 @@ export default EStyleSheet.create({
   detailsText: {
     color: '$primaryDarkGray',
     fontSize: 12,
+    textAlign: 'right',
   },
   popoverItemContent: {
     flexDirection: 'row',
     marginTop: 4,
+    justifyContent: 'space-between',
   },
   popoverContent: {
     marginTop: 4,
@@ -100,5 +102,6 @@ export default EStyleSheet.create({
     color: '$primaryDarkGray',
     fontSize: 12,
     fontWeight: 'bold',
+    textAlign: 'left',
   },
 });


### PR DESCRIPTION
### What does this PR?
fixed alignment issues in upvote popover in RTL layout. aligned the text to right and left according to position.

### Issue number
Trello: Upvote popup content is misaligned

### Screenshots/Video
![image](https://user-images.githubusercontent.com/48380998/148096966-ecdc1cee-b238-4165-b7f5-73735f1ef9aa.png)
