### PR TITLE
Nt/community link

### DIFF
--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -47,7 +47,7 @@ import { TouchableWithoutFeedback } from "react-native-gesture-handler";
     }
 
     return (
-      <TouchableWithoutFeedback onPress={onPress} disabled={!isAnchored}>
+      <TouchableWithoutFeedback onPress={onPress} disabled={isAnchored}>
         <FastImage 
           style={imgStyle}
           source={{uri:imgUrl}}

--- a/src/components/postHtmlRenderer/linkDataParser.ts
+++ b/src/components/postHtmlRenderer/linkDataParser.ts
@@ -9,6 +9,7 @@ export interface LinkData {
         proposal?:string,
         videoHref?:string,
         filter?:string,
+        community?:string,
 }
 
 export const parseLinkData = (tnode:TNode):LinkData => {
@@ -90,10 +91,16 @@ export const parseLinkData = (tnode:TNode):LinkData => {
 
   }
 
+  if(tnode.classes.includes('markdown-community-link')){
+    return {
+      type: 'markdown-community-link',
+      community: tnode.attributes['data-community'],
+      filter: tnode.attributes['data-filter'],
+    }
+  }
+
   if (tnode.classes.includes('markdown-video-link-youtube')) {
     var embedUrl = tnode.attributes['data-embed-src'];
-
-
 
     if (embedUrl) {
       return {

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -53,6 +53,7 @@ export const PostHtmlRenderer = memo(({
       tag,
       filter,
       videoHref,
+      community
     } = data;
 
     try {
@@ -97,6 +98,13 @@ export const PostHtmlRenderer = memo(({
         
         case 'markdown-proposal-link':
           setSelectedLink(href);
+          break;
+
+        case 'markdown-community-link':
+          //tag press also handles community by default
+          if(handleTagPress){
+            handleTagPress(community, filter)
+          }
           break;
           
         default:

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -168,7 +168,7 @@ export const PostHtmlRenderer = memo(({
       };
   
       const isVideoThumb = tnode.classes?.indexOf('video-thumbnail') >= 0;
-      const isAnchored = !(tnode.parent?.classes?.indexOf('markdown-external-link') >= 0)
+      const isAnchored = tnode.parent?.tagName === 'a';
   
       if(isVideoThumb){
         return <VideoThumb contentWidth={contentWidth} uri={imgUrl}/>;


### PR DESCRIPTION
### What does this PR?
Apparently there were two bugs causing the issue, one being markdown-community-link not supported by app and other anchored image was only entertaining markdown-external-link which now reply on <a/> tag as parent to disable core image press and let anchor handle click event only.

### Issue
https://trello.com/c/kanS8VQO/309-image-link-is-not-working-as-expected

### Screenshots/Video
https://user-images.githubusercontent.com/6298342/149085102-4102d3e4-4ec2-4c1c-834f-8a573856523d.mov



