### PR TITLE
removed text centering from p tag

### DIFF
--- a/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
+++ b/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
@@ -17,7 +17,6 @@ export default EStyleSheet.create({
     marginBottom:6,
     flexDirection:'row',
     alignItems:'center',
-    justifyContent:'center',
     flexWrap:'wrap'
 
   } as TextStyle,


### PR DESCRIPTION
### Issue number
https://trello.com/c/C1VRsr6o/310-comment-text-spanning-less-than-a-line-appears-centred

### Screenshots/Video
<img width="281" alt="Screenshot 2022-01-12 at 1 12 13 PM" src="https://user-images.githubusercontent.com/6298342/149088950-04b179bb-e088-4ae4-b897-44a3c7b753cf.png">

