### PR TITLE
Nt/yt start time

### DIFF
--- a/src/components/postElements/body/view/commentBodyView.tsx
+++ b/src/components/postElements/body/view/commentBodyView.tsx
@@ -28,6 +28,7 @@ import { OptionsModal } from '../../../atoms';
 import { useAppDispatch } from '../../../../hooks';
 import { isCommunity } from '../../../../utils/communityValidation';
 import { GLOBAL_POST_FILTERS_VALUE } from '../../../../constants/options/filters';
+import { startsWith } from 'core-js/core/string';
 
 const WIDTH = Dimensions.get('window').width;
 
@@ -53,6 +54,7 @@ const CommentBody = ({
   const [revealComment, setRevealComment] = useState(reputation > 0 && !isMuted);
   const [videoUrl, setVideoUrl] = useState(null);
   const [youtubeVideoId, setYoutubeVideoId] = useState(null)
+  const [videoStartTime, setVideoStartTime] = useState(0);
 
   const intl = useIntl();
   const actionImage = useRef(null);
@@ -264,9 +266,10 @@ const CommentBody = ({
     }
   };
 
-  const _handleYoutubePress = (videoId) => {
+  const _handleYoutubePress = (videoId, startTime) => {
     if (videoId && youtubePlayerRef.current) {
       setYoutubeVideoId(videoId);
+      setVideoStartTime(startTime);
       youtubePlayerRef.current.setModalVisible(true);
     }
   };
@@ -274,6 +277,7 @@ const CommentBody = ({
   const _handleVideoPress = (embedUrl) => {
     if (embedUrl && youtubePlayerRef.current) {
       setVideoUrl(embedUrl);
+      setVideoStartTime(0)
       youtubePlayerRef.current.setModalVisible(true);
     }
   };
@@ -364,7 +368,7 @@ const CommentBody = ({
           setVideoUrl(null);
         }}
       >
-        <VideoPlayerSheet youtubeVideoId={youtubeVideoId} videoUrl={videoUrl} />
+        <VideoPlayerSheet youtubeVideoId={youtubeVideoId} videoUrl={videoUrl} startTime={videoStartTime} />
       </ActionsSheetView>
     </Fragment>
   );

--- a/src/components/postElements/body/view/postBodyView.js
+++ b/src/components/postElements/body/view/postBodyView.js
@@ -32,6 +32,7 @@ const PostBody = ({ navigation, body, dispatch, onLoadEnd }) => {
   const [html, setHtml] = useState('');
   const [youtubeVideoId, setYoutubeVideoId] = useState(null);
   const [videoUrl, setVideoUrl] = useState(null);
+  const [videoStartTime, setVideoStartTime] = useState(0);
 
   const intl = useIntl();
   const actionImage = useRef(null);
@@ -44,9 +45,10 @@ const PostBody = ({ navigation, body, dispatch, onLoadEnd }) => {
     }
   }, [body]);
 
-  const _handleYoutubePress = (videoId) => {
+  const _handleYoutubePress = (videoId, startTime) => {
     if (videoId && youtubePlayerRef.current) {
       setYoutubeVideoId(videoId);
+      setVideoStartTime(startTime);
       youtubePlayerRef.current.setModalVisible(true);
     }
   };
@@ -54,6 +56,7 @@ const PostBody = ({ navigation, body, dispatch, onLoadEnd }) => {
   const _handleVideoPress = (embedUrl) => {
     if (embedUrl && youtubePlayerRef.current) {
       setVideoUrl(embedUrl);
+      setVideoStartTime(0);
       youtubePlayerRef.current.setModalVisible(true);
     }
   };
@@ -291,7 +294,11 @@ const PostBody = ({ navigation, body, dispatch, onLoadEnd }) => {
           setVideoUrl(null);
         }}
       >
-        <VideoPlayerSheet youtubeVideoId={youtubeVideoId} videoUrl={videoUrl} />
+        <VideoPlayerSheet
+          youtubeVideoId={youtubeVideoId}
+          videoUrl={videoUrl}
+          startTime={videoStartTime}
+        />
       </ActionSheetView>
 
       <OptionsModal

--- a/src/components/postElements/body/view/videoPlayerSheet.tsx
+++ b/src/components/postElements/body/view/videoPlayerSheet.tsx
@@ -1,16 +1,16 @@
 import React, {useState} from 'react';
 import { Dimensions } from 'react-native';
 import { View, StyleSheet, ActivityIndicator } from 'react-native';
-import AutoHeightWebView from 'react-native-autoheight-webview';
 import WebView from 'react-native-webview';
-import YoutubeIframe from 'react-native-youtube-iframe';
+import YoutubeIframe, { InitialPlayerParams } from 'react-native-youtube-iframe';
 
 interface VideoPlayerSheetProps {
     youtubeVideoId?:string;
     videoUrl?:string;
+    startTime?:number;
 }
 
-const VideoPlayerSheet = ({youtubeVideoId, videoUrl}: VideoPlayerSheetProps) => {
+const VideoPlayerSheet = ({youtubeVideoId, videoUrl, startTime}: VideoPlayerSheetProps) => {
 
     const PLAYER_HEIGHT = Dimensions.get('screen').width * (9/16);
 
@@ -30,6 +30,10 @@ const VideoPlayerSheet = ({youtubeVideoId, videoUrl}: VideoPlayerSheetProps) => 
         setLoading(false)
     }
 
+    const initialParams:InitialPlayerParams = {
+        start:startTime
+    }
+
     return (
         <View style={styles.container}>
             
@@ -37,6 +41,7 @@ const VideoPlayerSheet = ({youtubeVideoId, videoUrl}: VideoPlayerSheetProps) => 
                 <YoutubeIframe 
                     height={PLAYER_HEIGHT} 
                     videoId={youtubeVideoId} 
+                    initialPlayerParams={initialParams}
                     onReady={_onReady} 
                     play={shouldPlay} 
                     onChangeState={_onChangeState} 

--- a/src/components/postHtmlRenderer/linkDataParser.ts
+++ b/src/components/postHtmlRenderer/linkDataParser.ts
@@ -9,6 +9,7 @@ export interface LinkData {
         proposal?:string,
         videoHref?:string,
         youtubeId?:string,
+        startTime?:number,
         filter?:string,
         community?:string,
 }
@@ -24,10 +25,13 @@ export const parseLinkData = (tnode:TNode):LinkData => {
       //attribute if that is the case, use in app video modal to play content
       //for now, only youtube id is supported
       const youtubeId = tnode.attributes['data-youtube']
+      const startTime= tnode.attributes['data-start-time'];
       if(youtubeId){
+        
         return {
           type:'markdown-video-link-youtube',
-          youtubeId:youtubeId.length > 11 && youtubeId[12] === '?' ? youtubeId.substring(0,11):youtubeId //this is a workaround to avoid feeding query parameters to youtube player
+          youtubeId:youtubeId,
+          startTime:parseInt(startTime) || 0,
         }
       }
       //TOOD: support other video link later
@@ -116,11 +120,13 @@ export const parseLinkData = (tnode:TNode):LinkData => {
 
   if (tnode.classes.includes('markdown-video-link-youtube')) {
     var youtubeId = tnode.attributes['data-youtube'];
+    const startTime= tnode.attributes['data-start-time'];
 
     if (youtubeId) {
       return {
         type: 'markdown-video-link-youtube',
-        youtubeId : youtubeId.length > 11 && youtubeId[12] === '?' ? youtubeId.substring(0,11):youtubeId //this is a workaround to avoid feeding query parameters to youtube player
+        youtubeId : youtubeId,
+        startTime : parseInt(startTime) || 0,
       };
     }
   }

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -9,7 +9,7 @@ import { AutoHeightImage } from "../autoHeightImage/autoHeightImage";
 interface PostHtmlRendererProps {
   contentWidth:number;
   body:string;
-  onLoaded:()=>void;
+  onLoaded?:()=>void;
   setSelectedImage:(imgUrl:string)=>void;
   setSelectedLink:(url:string)=>void;
   onElementIsImage:(imgUrl:string)=>void;
@@ -17,7 +17,7 @@ interface PostHtmlRendererProps {
   handleOnUserPress:(username:string)=>void;
   handleTagPress:(tag:string, filter?:string)=>void;
   handleVideoPress:(videoUrl:string)=>void;
-  handleYoutubePress:(videoId:string)=>void;
+  handleYoutubePress:(videoId:string, startTime:number)=>void;
 }
 
 export const PostHtmlRenderer = memo(({

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -52,6 +52,7 @@ export const PostHtmlRenderer = memo(({
       permlink,
       tag,
       youtubeId,
+      startTime,
       filter,
       videoHref,
       community
@@ -87,7 +88,7 @@ export const PostHtmlRenderer = memo(({
           break;
         case 'markdown-video-link-youtube':
           if(handleYoutubePress){
-            handleYoutubePress(youtubeId)
+            handleYoutubePress(youtubeId, startTime)
           }
       
           break;


### PR DESCRIPTION
### What does this PR?
Youtube video player now support start time in both main post detail body and comments. 

### Issue
https://trello.com/c/TavhZ6Sa/314-add-support-for-data-start-time-youtube-videos

### Screenshots/Video
post body Inline video starting at 4:55.
https://user-images.githubusercontent.com/6298342/149633026-20e26a74-42a1-42a5-bc4d-7540231f0189.mov

Comment Video, first video is without start time and second link starts at 72 seconds.
https://user-images.githubusercontent.com/6298342/149633030-8c699269-7746-4956-b5fd-99351593dde1.mov


