### PR TITLE
optimised table img width based on number of columns

### DIFF
--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -37,6 +37,7 @@ export const PostHtmlRenderer = memo(({
      //new renderer functions
   body = body.replace(/<center>/g, '<div class="text-center">').replace(/<\/center>/g,'</div>');
 
+
   console.log("Comment body:", body);
 
   const _handleOnLinkPress = (data:LinkData) => {
@@ -157,6 +158,26 @@ export const PostHtmlRenderer = memo(({
         />
       );
     }
+
+    //this method checks if image is a child of table column
+    //and calculates img width accordingly,
+    //returns full width if img is not part of table
+    const getMaxImageWidth = (tnode:TNode)=>{
+      
+      //return full width if not parent exist
+      if(!tnode.parent || tnode.parent.tagName === 'body'){
+        return contentWidth;
+      }
+
+      //return divided width based on number td tags
+      if(tnode.parent.tagName === 'td'){
+        const cols = tnode.parent.parent.children.length
+        return contentWidth/cols;
+      }
+
+      //check next parent
+      return getMaxImageWidth(tnode.parent);
+    }
   
   
     const _imageRenderer = ({
@@ -172,14 +193,15 @@ export const PostHtmlRenderer = memo(({
       const isVideoThumb = tnode.classes?.indexOf('video-thumbnail') >= 0;
       const isAnchored = tnode.parent?.tagName === 'a';
   
+
       if(isVideoThumb){
         return <VideoThumb contentWidth={contentWidth} uri={imgUrl}/>;
       }
-
       else {
+        const maxImgWidth = getMaxImageWidth(tnode);
         return (
           <AutoHeightImage 
-            contentWidth={contentWidth} 
+            contentWidth={maxImgWidth} 
             imgUrl={imgUrl}
             isAnchored={isAnchored}
             onPress={_onPress}


### PR DESCRIPTION
### What does this PR?
Recursively search for col parent if image is not a part of any columns it return maximum available width otherwise optimises width based on number of columns in a table.

Trade off is, for normal image it would still do search though it would mostly end at 1 or max 2 recursive calls for regular images which should not pose much performance hit.

I am open to suggestion as to how we can further improve the methodology.

### Issue
https://trello.com/c/EMsolR81/316-bug-table-and-images-alignment

### Screenshots/Video
<img width="350" alt="Screenshot 2022-01-16 at 5 47 09 PM" src="https://user-images.githubusercontent.com/6298342/149661015-add5d9c7-d50c-4cb4-81d4-14ef09f283a7.png">

<img width="351" alt="Screenshot 2022-01-16 at 5 47 26 PM" src="https://user-images.githubusercontent.com/6298342/149661024-b1233f5b-2408-4ecc-9235-bf5823f7d29b.png">

<img width="354" alt="Screenshot 2022-01-16 at 5 58 22 PM" src="https://user-images.githubusercontent.com/6298342/149660922-fd7d0072-62bf-480b-9d80-91ce96198969.png">