### PR TITLE
sticking text-justify to auto for android

### DIFF
--- a/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
+++ b/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
@@ -1,4 +1,4 @@
-import { ImageStyle } from 'react-native';
+import { ImageStyle, Platform } from 'react-native';
 import { ViewStyle, TextStyle } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 
@@ -82,7 +82,7 @@ export default EStyleSheet.create({
     flexWrap:'wrap'
   } as TextStyle,
   textJustify:{
-    textAlign:'justify',
+    textAlign: Platform.select({ios:'justify', android:'auto'}), //justify with selectable on android causes ends of text getting clipped, 
     letterSpacing:0
   } as TextStyle,
   revealButton: {


### PR DESCRIPTION
### What does this PR?
justify textAlign with selectable enabled was doing more harm then good, the ends text was getting clipped with this set of props.

Since selectable is more important for us, for now I am ignoring justify for android so the presentation of content is not affected.

### Issue number
#2157 

### Screenshots/Video
Before
<img width="343" alt="Screenshot 2022-01-27 at 1 29 09 PM" src="https://user-images.githubusercontent.com/6298342/151321685-11f57313-b64a-4a32-9731-fc18bfb0427d.png">

Now
<img width="339" alt="Screenshot 2022-01-27 at 1 32 09 PM" src="https://user-images.githubusercontent.com/6298342/151321663-d06ea3db-511c-4a6d-9a83-c0c1b9a51456.png">

