### PR TITLE
fixes misfired user search 

### DIFF
--- a/src/components/markdownEditor/view/usernameAutofillBar.tsx
+++ b/src/components/markdownEditor/view/usernameAutofillBar.tsx
@@ -29,6 +29,7 @@ export const UsernameAutofillBar = ({text, selection, onApplyUsername}:Props) =>
             } else {
               setSearchedUsers([]);
               setQuery('')
+              _handleUserSearch.cancel();
             }
           }
     }, [text, selection])
@@ -46,7 +47,7 @@ export const UsernameAutofillBar = ({text, selection, onApplyUsername}:Props) =>
         setSearchedUsers(users);
       }
         
-      }, 200);
+      }, 200, {leading:true});
 
 
     


### PR DESCRIPTION
Instead of firing debounce on trailing edge by default, we now run on leading edge, this not just makes sure avoid delayed misfire but also improves the regular user experience. Also added debounce cancellation for added redundancy. 

### Screenshots/Video
https://user-images.githubusercontent.com/6298342/151655872-98ae2023-8784-4fff-8af7-b0f96e28bde5.mov


