### PR TITLE
updated share content props for refering

### DIFF
--- a/src/components/sideMenu/view/sideMenuView.js
+++ b/src/components/sideMenu/view/sideMenuView.js
@@ -75,8 +75,9 @@ const SideMenuView = ({
     }
 
     if (item.id === 'refer') {
+      const shareUrl = `https://ecency.com/signup?referral=${currentAccount.username}`;
       Share.share({
-        url: `https://ecency.com/signup?referral=${currentAccount.username}`,
+        message: shareUrl,
       });
       return;
     }


### PR DESCRIPTION
### What does this PR?
Apparently android do not recognise shared url, yet message prop is the one both platforms recognise

### Screenshots/Video
![Screenshot 2022-01-30 at 9 50 47 PM](https://user-images.githubusercontent.com/6298342/151708999-d261284c-f90e-4141-b3d0-720fb97e3311.png)


