### PR TITLE
fixed image size in th tag inside table

### DIFF
--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -37,7 +37,7 @@ import { TouchableWithoutFeedback } from "react-native-gesture-handler";
     }
 
     const imgStyle = {
-      width:imgWidth, 
+      width:imgWidth - 10, 
       height:imgHeight, 
       backgroundColor: onLoadCalled ? 'transparent' : EStyleSheet.value('$primaryGray')
     }

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -176,7 +176,7 @@ export const PostHtmlRenderer = memo(
       }
 
       //return divided width based on number td tags
-      if (tnode.parent.tagName === 'td') {
+      if (tnode.parent.tagName === 'td' || tnode.parent.tagName === 'th') {
         const cols = tnode.parent.parent.children.length;
         return contentWidth / cols;
       }


### PR DESCRIPTION
### What does this PR?
Fixes image size when used inside th tag in table. Previously images get whole screen width inside th tag inside tables.  Adjusted the image width acording to th and td tags.

### Steps to reproduce
[This post](https://ecency.com/hive-131578/@enginewitty/what-if) is using images inside table and images are getting whole screen widths. 


### Screenshots/Video
![image](https://user-images.githubusercontent.com/48380998/154270205-67cb3e02-3bdb-48ad-a246-13f745ecbd2f.png)
