### PR TITLE
editor screen tooltip bug

### DIFF
--- a/src/components/markdownEditor/view/markdownEditorView.js
+++ b/src/components/markdownEditor/view/markdownEditorView.js
@@ -108,6 +108,11 @@ const MarkdownEditorView = ({
   useEffect(() => {
     if (onLoadDraftPress) {
       setShowDraftLoadButton(true);
+      if (!draftBtnTooltipRegistered) {
+        setTimeout(() => {
+          tooltipRef.current?.openTooltip();
+        }, 300);
+      }
     }
   }, [onLoadDraftPress]);
 
@@ -306,13 +311,11 @@ const MarkdownEditorView = ({
         setShowDraftLoadButton(false);
         onLoadDraftPress();
       };
+
+      const Wrapper = draftBtnTooltipRegistered ? AnimatedView : View;
       return (
         <>
-          <AnimatedView
-            style={styles.floatingContainer}
-            animation="bounceInRight"
-            onAnimationEnd={() => tooltipRef.current?.openTooltip()}
-          >
+          <Wrapper style={styles.floatingContainer} animation="bounceInRight">
             <Tooltip
               ref={tooltipRef}
               text={intl.formatMessage({ id: 'walkthrough.load_draft_tooltip' })}
@@ -328,7 +331,7 @@ const MarkdownEditorView = ({
                 isLoading={isLoading}
               />
             </Tooltip>
-          </AnimatedView>
+          </Wrapper>
         </>
       );
     }

--- a/src/components/markdownEditor/view/markdownEditorView.js
+++ b/src/components/markdownEditor/view/markdownEditorView.js
@@ -96,6 +96,8 @@ const MarkdownEditorView = ({
   const isVisibleAccountsBottomSheet = useSelector(
     (state) => state.ui.isVisibleAccountsBottomSheet,
   );
+  const draftBtnTooltipState = useSelector((state) => state.walkthrough.walkthroughMap);
+  const draftBtnTooltipRegistered = draftBtnTooltipState.get(walkthrough.EDITOR_DRAFT_BTN);
 
   useEffect(() => {
     if (!isPreviewActive) {
@@ -167,7 +169,7 @@ const MarkdownEditorView = ({
   }, [draftBody]);
 
   useEffect(() => {
-    if (autoFocusText && inputRef && inputRef.current) {
+    if (autoFocusText && inputRef && inputRef.current && draftBtnTooltipRegistered) {
       inputRef.current.focus();
     }
   }, [autoFocusText]);
@@ -440,7 +442,7 @@ const MarkdownEditorView = ({
             <TextInput
               multiline
               autoCorrect={true}
-              autoFocus={isReply ? true : false}
+              autoFocus={isReply && draftBtnTooltipRegistered ? true : false}
               onChangeText={_changeText}
               onSelectionChange={_handleOnSelectionChange}
               placeholder={intl.formatMessage({

--- a/src/components/tooltip/tooltipView.tsx
+++ b/src/components/tooltip/tooltipView.tsx
@@ -61,8 +61,8 @@ const Tooltip = ({ children, text, walkthroughIndex }: TooltipProps, ref) => {
         visible={showPopover}
         onClose={() => ref?.current?.closeTooltip()}
         fromRect={popoverAnchor}
-        placement="top"
         supportedOrientations={['portrait', 'landscape']}
+
       >
         <Text>{text}</Text>
       </Popover>

--- a/src/components/tooltip/tooltipView.tsx
+++ b/src/components/tooltip/tooltipView.tsx
@@ -59,7 +59,7 @@ const Tooltip = ({ children, text, walkthroughIndex }: TooltipProps, ref) => {
         contentStyle={styles.popoverDetails}
         arrowStyle={styles.arrow}
         visible={showPopover}
-        onClose={() => setShowPopover(false)}
+        onClose={() => ref?.current?.closeTooltip()}
         fromRect={popoverAnchor}
         placement="top"
         supportedOrientations={['portrait', 'landscape']}


### PR DESCRIPTION
### What does this PR?

- Fixes the app crash caused by usePopover hook provided by react-native-modal-popover
- changed tooltip implementation to custom controls instead of hooks and methods provided by the module
- fixes the keyboard causing tooltip disaligment in editor screen.


### Steps to reproduce
Uninstall and reinstall the app or clear app data to see tooltip at first app start.
Go to editor screen and tooltip will load after Draft button is rendered.


### Screenshots/Video

https://user-images.githubusercontent.com/48380998/155351999-311ed617-cb19-423e-9eff-346bb903abda.mp4



