### PR TITLE
Nt/comment cache delete

### DIFF
--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -233,7 +233,7 @@ const CommentView = ({
               onPress={() => handleOnEditPress && handleOnEditPress(comment)}
               iconType="MaterialIcons"
             />
-            {!childCount && !activeVotes.length && isCommentDeletable && (
+            {!childCount && !activeVotes.length && comment.isDeletable && (
               <Fragment>
                 <IconButton
                   size={20}
@@ -283,8 +283,7 @@ const CommentView = ({
   }
 
   const customContainerStyle = commentNumber > 2 ? {marginLeft: 44}:null
-  const isCommentDeletable = comment && !(comment.children > 0 || comment.net_rshares > 0 || comment.is_paidout);
-  
+
   return (
     <Fragment>
       <View style={{...styles.commentContainer, ...customContainerStyle}}>

--- a/src/redux/actions/cacheActions.ts
+++ b/src/redux/actions/cacheActions.ts
@@ -49,6 +49,7 @@ import { Comment, Vote } from '../reducers/cacheReducer';
     comment.author_reputation = comment.author_reputation || 25;
     comment.total_payout = comment.total_payout || 0;
     comment.json_metadata = comment.json_metadata || makeJsonMetadataReply(options.parentTags)
+    comment.isDeletable = comment.isDeletable || true;
 
     comment.body = renderPostBody({
       author:comment.author,

--- a/src/redux/reducers/cacheReducer.ts
+++ b/src/redux/reducers/cacheReducer.ts
@@ -20,6 +20,7 @@ export interface Comment {
     net_rshares?:number,
     active_votes?:Array<{rshares:number, voter:string}>,
     json_metadata?:any,
+    isDeletable?:boolean,
     created?:string, //handle created and updated separatly
     updated?:string,
     expiresAt?:number,

--- a/src/utils/postParser.tsx
+++ b/src/utils/postParser.tsx
@@ -165,6 +165,8 @@ export const parseComment = (comment:any) => {
 
   comment.total_payout = totalPayout;
 
+  comment.isDeletable = !(comment.active_votes?.length > 0 ||comment.children > 0 || comment.net_rshares > 0 || comment.is_paidout);
+
   //stamp comments with fetched time;
   comment.post_fetched_at = new Date().getTime();
 


### PR DESCRIPTION
Supporting deletable property cache, if comment is deletable or not deletable, it is tracked in cache after edit.

<img width="255" alt="Screenshot 2022-03-16 at 2 43 23 AM" src="https://user-images.githubusercontent.com/6298342/158477757-38eff11b-ec4b-4891-8be6-1a26b471ebd9.png">

fixes #2226