### PR TITLE
using touchable from react-native instead of gesture handler

### DIFF
--- a/src/screens/editor/children/thumbSelectionContent.tsx
+++ b/src/screens/editor/children/thumbSelectionContent.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { Alert, Text, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
-import { FlatList, TouchableOpacity } from 'react-native-gesture-handler';
+import { FlatList } from 'react-native-gesture-handler';
 import { extractImageUrls } from '../../../utils/editor';
 import styles from './styles';
 

--- a/src/screens/editor/children/thumbSelectionModal.tsx
+++ b/src/screens/editor/children/thumbSelectionModal.tsx
@@ -1,12 +1,12 @@
 import React, { useImperativeHandle, useRef, useState } from 'react';
-import { FlatList, TouchableOpacity } from 'react-native-gesture-handler';
+import { FlatList } from 'react-native-gesture-handler';
 import ActionSheet from 'react-native-actions-sheet';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import styles from './styles';
 import { extractImageUrls } from '../../../utils/editor';
 import FastImage from 'react-native-fast-image';
 import { forwardRef } from 'react';
-import { View, Text, Alert } from 'react-native';
+import { View, Text, Alert, TouchableOpacity } from 'react-native';
 import { useIntl } from 'react-intl';
 
 


### PR DESCRIPTION
Fixed thumb selection issues, oddly enough, I tried changing the same in delegateScreen and the touchable rather stopped working, there is something more to it that we do not understand, in some places touchableOpacity from gesture-handler work and in others default react-native one works.

### Screenshots/Video
<img width="357" alt="Screenshot 2022-03-16 at 3 13 47 AM" src="https://user-images.githubusercontent.com/6298342/158481466-00e65647-c1cc-4cc7-a4f8-36b67e0b2ad7.png">

