### PR TITLE
fixed dots alignment in comment

### DIFF
--- a/src/components/postElements/headerDescription/view/postHeaderDescriptionStyles.js
+++ b/src/components/postElements/headerDescription/view/postHeaderDescriptionStyles.js
@@ -7,6 +7,7 @@ export default EStyleSheet.create({
   },
   leftContainer: {
     flexDirection: 'column',
+    flex: 1,
   },
   primaryDetails: {
     flexDirection: 'row',


### PR DESCRIPTION
### What does this PR?
fixes #2221 . Set the flex to 1 taking up the whole space and align the dots to end.

### Issue number
#2221 

### Screenshots/Video
![image](https://user-images.githubusercontent.com/48380998/158548126-5d8baa6f-1d45-45a3-baf0-6085dd2fd5ed.png)
