### PR TITLE
Nt/table-div-fix

### DIFF
--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -281,9 +281,9 @@ export const PostHtmlRenderer = memo(
           img: styles.img,
           table: styles.table,
           tr: { ...styles.tr, width: contentWidth }, //center tag causes tr to have 0 width if not exclusivly set, contentWidth help avoid that
-          th: {...styles.th, minWidth: _minTableColWidth},
-          td: {...styles.td, minWidth: _minTableColWidth},
-          div:{width:contentWidth},
+          th: { ...styles.th, minWidth: _minTableColWidth},
+          td: { ...styles.td, minWidth: _minTableColWidth},
+          div: { ...styles.div, maxWidth:contentWidth }, //makes sure width covers the available horizontal space for view and not exceed the contentWidth if parent bound id not defined
           blockquote: styles.blockquote,
           code: styles.code,
           li: styles.li,

--- a/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
+++ b/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
@@ -12,13 +12,15 @@ export default EStyleSheet.create({
   body: {
     color: '$primaryBlack',
   } as TextStyle,
+  div: {
+    width:'100%',
+  },
   p:{
     marginTop:6,
     marginBottom:6,
     flexDirection:'row',
     alignItems:'center',
     flexWrap:'wrap'
-
   } as TextStyle,
   pLi:{
     marginTop:0,


### PR DESCRIPTION
### What does this PR?
updated div bounds logic

The sample post's cell content was wrapped in a a div, which caused the issue we were facing as div is by default given available contentWidth, a fix that was added to avoid div related issues, now I am setting div width to 100% available width but limiting it to max contentWidth so it makes sure div content is alwasy taking full space while making sure of it's bounds not exceeding content width (screen width).


### Issue number
fixes #2231 2231

### Screenshots/Video
![Screenshot 2022-03-20 at 6 34 31 PM](https://user-images.githubusercontent.com/6298342/159165239-c40b4a7f-9ff9-43e1-9261-b43feb976017.png)
