### PR TITLE
fixes date time selection bug in post scheduling

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -324,7 +324,7 @@ PODS:
     - react-native-config/App (= 1.4.2)
   - react-native-config/App (1.4.2):
     - React-Core
-  - react-native-date-picker (3.2.10):
+  - react-native-date-picker (4.2.0):
     - React-Core
   - react-native-matomo-sdk (0.4.1):
     - MatomoTracker (~> 7)
@@ -762,7 +762,7 @@ SPEC CHECKSUMS:
   react-native-camera: 3eae183c1d111103963f3dd913b65d01aef8110f
   react-native-cameraroll: e2917a5e62da9f10c3d525e157e25e694d2d6dfa
   react-native-config: c98128a72bc2c3a1ca72caec0b021f0fa944aa29
-  react-native-date-picker: 242eec7af56cea5fb2706d5db5d3837060b3884b
+  react-native-date-picker: d83ab9cccbc497642a93fdca783ae76ecd6b17b6
   react-native-matomo-sdk: 025c54f92e1e26a4d0acee7c3f28cb0fc7e4729c
   react-native-netinfo: 30fb89fa913c342be82a887b56e96be6d71201dd
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-native-chart-kit": "^6.11.0",
     "react-native-config": "luggit/react-native-config#master",
     "react-native-crypto": "^2.2.0",
-    "react-native-date-picker": "^3.2.7",
+    "react-native-date-picker": "^4.2.0",
     "react-native-dynamic": "^1.0.0",
     "react-native-extended-stylesheet": "^0.10.0",
     "react-native-fast-image": "^8.3.2",

--- a/src/components/dateTimePicker/view/dateTimePickerStyles.js
+++ b/src/components/dateTimePicker/view/dateTimePickerStyles.js
@@ -1,6 +1,10 @@
 import EStyleSheet from 'react-native-extended-stylesheet';
 
 export default EStyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   btnTextCancel: {
     color: '$iconColor',
   },

--- a/src/components/dateTimePicker/view/dateTimePickerView.js
+++ b/src/components/dateTimePicker/view/dateTimePickerView.js
@@ -1,5 +1,5 @@
 import React, { useState, useRef, forwardRef } from 'react';
-import { Platform } from 'react-native';
+import { Platform, View } from 'react-native';
 import DatePicker from 'react-native-date-picker';
 import moment from 'moment';
 import { FormattedDate, useIntl } from 'react-intl';
@@ -28,16 +28,19 @@ const DateTimePickerView = React.forwardRef(({ type, iconName, disabled, onChang
   };
 
   return (
-    <DatePicker
-      textColor={styles.datePickerText.color}
-      date={date}
-      onDateChange={_setDate}
-      style={styles.picker}
-      minimumDate={new Date()}
-      androidVariant="iosClone"
-      is24hourSource="device"
-      locale={getLocale()}
-    />
+    <View style={styles.container}>
+      <DatePicker
+        textColor={styles.datePickerText.color}
+        date={date}
+        onDateChange={_setDate}
+        style={styles.picker}
+        minimumDate={new Date()}
+        androidVariant="iosClone"
+        is24hourSource="device"
+        locale={getLocale()}
+        mode={type}
+      />
+    </View>
   );
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8604,10 +8604,10 @@ react-native-crypto@^2.2.0:
     public-encrypt "^4.0.0"
     randomfill "^1.0.3"
 
-react-native-date-picker@^3.2.7:
-  version "3.2.10"
-  resolved "https://registry.yarnpkg.com/react-native-date-picker/-/react-native-date-picker-3.2.10.tgz#5e690db8e628255d8390e33b1e6f8fa9477f6fb9"
-  integrity sha512-/fA+htnZcr3rBw3eaOR/DvMwGLDTg59MCiiluin5YcHBxNZQYs/uYp/l6Hf719qZXndPGcixS46YIgso4Jf4gg==
+react-native-date-picker@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-date-picker/-/react-native-date-picker-4.2.0.tgz#c47521112f15b9d68333602373d112fc84257d97"
+  integrity sha512-IfbK7Eh5By8rdjiu/pvqLF8NkFX9pVsY7Vn6+MkLSiFcLIGFd7NaENRJKl75/xNZuY5CkIiRVksS9abEl/II8g==
 
 react-native-dynamic@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What does this PR?
This PR fixes the date time not showing correctly in post scheduling options modal  in iPads. Main issue was due to alignment of date time picker component due to large screen of iPad. check screenshots for reference

### Issue number
https://ecency.com/hive-125125/@artby.dara/re-ecency-2022323t132324768z

### Screenshots/Video
![image](https://user-images.githubusercontent.com/48380998/161115166-bc66323d-99c6-434d-b628-f5bee00ad339.png)

![image](https://user-images.githubusercontent.com/48380998/161115691-b1f0aa18-5246-40ff-874b-cc1a5a056195.png)

