### PR TITLE
Nt/smooth notification content

### DIFF
--- a/src/screens/notification/container/notificationContainer.js
+++ b/src/screens/notification/container/notificationContainer.js
@@ -26,7 +26,7 @@ class NotificationContainer extends Component {
       notifications: [],
       notificationsMap: new Map(),
       lastNotificationId: null,
-      isRefreshing: false,
+      isRefreshing: true,
       isLoading: false,
       selectedFilter: 'activities',
       endOfNotification: false,
@@ -70,7 +70,6 @@ class NotificationContainer extends Component {
               : res;
             notificationsMap.set(type, _notifications);
             this.setState({
-              // notifications: loadMore ? unionBy(notifications, res, 'id') : res,
               notificationsMap,
               lastNotificationId: lastId,
               isRefreshing: false,
@@ -188,7 +187,7 @@ class NotificationContainer extends Component {
 
   render() {
     const { isLoggedIn, globalProps } = this.props;
-    const { notificationsMap, selectedFilter, isRefreshing } = this.state;
+    const { notificationsMap, selectedFilter, isRefreshing, isLoading } = this.state;
 
     const _notifications = notificationsMap.get(selectedFilter) || [];
     return (
@@ -203,6 +202,7 @@ class NotificationContainer extends Component {
         isLoggedIn={isLoggedIn}
         changeSelectedFilter={this._changeSelectedFilter}
         globalProps={globalProps}
+        isLoading={isLoading}
       />
     );
   }

--- a/src/screens/notification/container/notificationContainer.js
+++ b/src/screens/notification/container/notificationContainer.js
@@ -7,7 +7,6 @@ import { injectIntl } from 'react-intl';
 
 // Actions and Services
 import { unionBy } from 'lodash';
-import reactotron from 'reactotron-react-native';
 import { getNotifications, markNotifications } from '../../../providers/ecency/ecency';
 import { updateUnreadActivityCount } from '../../../redux/actions/accountAction';
 
@@ -25,6 +24,7 @@ class NotificationContainer extends Component {
     super(props);
     this.state = {
       notifications: [],
+      notificationsMap: new Map(),
       lastNotificationId: null,
       isRefreshing: false,
       isLoading: false,
@@ -42,7 +42,7 @@ class NotificationContainer extends Component {
   }
 
   _getActivities = (type = 'activities', loadMore = false) => {
-    const { lastNotificationId, notifications, endOfNotification, isLoading } = this.state;
+    const { lastNotificationId, endOfNotification, isLoading, notificationsMap } = this.state;
     const since = loadMore ? lastNotificationId : null;
 
     if (isLoading) {
@@ -65,8 +65,13 @@ class NotificationContainer extends Component {
               isLoading: false,
             });
           } else {
+            const _notifications = loadMore
+              ? unionBy(notificationsMap.get(type) || [], res, 'id')
+              : res;
+            notificationsMap.set(type, _notifications);
             this.setState({
-              notifications: loadMore ? unionBy(notifications, res, 'id') : res,
+              // notifications: loadMore ? unionBy(notifications, res, 'id') : res,
+              notificationsMap,
               lastNotificationId: lastId,
               isRefreshing: false,
               isLoading: false,
@@ -166,7 +171,7 @@ class NotificationContainer extends Component {
   };
 
   _changeSelectedFilter = async (value, ind) => {
-    await this.setState({ selectedFilter: value, endOfNotification: false, selectedIndex: ind });
+    this.setState({ selectedFilter: value, endOfNotification: false, selectedIndex: ind });
   };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -183,12 +188,13 @@ class NotificationContainer extends Component {
 
   render() {
     const { isLoggedIn, globalProps } = this.props;
-    const { notifications, isRefreshing } = this.state;
+    const { notificationsMap, selectedFilter, isRefreshing } = this.state;
 
+    const _notifications = notificationsMap.get(selectedFilter) || [];
     return (
       <NotificationScreen
         getActivities={this._getActivities}
-        notifications={notifications}
+        notifications={_notifications}
         navigateToNotificationRoute={this._navigateToNotificationRoute}
         handleOnUserPress={this._handleOnUserPress}
         readAllNotification={this._readAllNotification}

--- a/src/screens/notification/screen/notificationScreen.js
+++ b/src/screens/notification/screen/notificationScreen.js
@@ -19,6 +19,7 @@ const NotificationScreen = ({
   handleOnUserPress,
   readAllNotification,
   isNotificationRefreshing,
+  isLoading,
   changeSelectedFilter,
   globalProps,
 }) => {
@@ -47,6 +48,7 @@ const NotificationScreen = ({
                   handleOnUserPress={handleOnUserPress}
                   readAllNotification={readAllNotification}
                   isNotificationRefreshing={isNotificationRefreshing}
+                  isLoading={isLoading}
                   changeSelectedFilter={changeSelectedFilter}
                   globalProps={globalProps}
                 />


### PR DESCRIPTION
### What does this PR?
This is first iteration of notification tabs content improvement, but already it's substantial improvement. 

### Note
The experience can be further improved by maintaining separate tabs state and integrated cache to fetch first notification page on startup and show that. The overall experience can be made as smooth as primary posts tab experience. 

But before jumping into that need to assess if it's worth spending that much time improving this experience, after experience the current update, only this PR iteration should seems good enough.


@feruzm need your thoughts.

### Where should the reviewer start?
Explore notification filters

### Issue number
fixes #2149 

### Screenshots/Video
**Before**
https://user-images.githubusercontent.com/6298342/163291378-c19c4367-ebfc-4326-b10e-4a2070fea017.mov

**After**
https://user-images.githubusercontent.com/6298342/163291407-4dc65dd6-c5fe-4c77-a759-c583b0aa6abc.mov


