### PR TITLE
Nt/table inline header

### DIFF
--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -9,6 +9,7 @@ import WebView from 'react-native-webview';
 import { VideoPlayer } from '..';
 import { useHtmlTableProps } from '@native-html/table-plugin';
 import { ScrollView } from 'react-native-gesture-handler';
+import { prependChild, removeElement } from 'htmlparser2/node_modules/domutils';
 
 interface PostHtmlRendererProps {
   contentWidth: number;
@@ -142,11 +143,48 @@ export const PostHtmlRenderer = memo(
     };
 
 
+
+    //Does some needed dom modifications for proper rendering
     const _onElement = (element: Element) => {
       if (element.tagName === 'img' && element.attribs.src) {
         const imgUrl = element.attribs.src;
         console.log('img element detected', imgUrl);
         onElementIsImage(imgUrl);
+      }
+
+      
+      //this avoids invalid rendering of first element of table pushing rest of columsn to extreme right.
+      if(element.tagName === 'table'){
+        console.log('table detected')
+
+        element.children.forEach((child)=>{
+          if(child.name === 'tr'){
+            let headerIndex = -1;
+            let colIndex = -1;
+            
+            child.children.forEach((gChild, index) => {
+              //check if element of row in table is not a column while it's other siblings are columns
+              if(gChild.type === 'tag'){
+                if(gChild.name !== 'td' && headerIndex === -1){
+                  headerIndex = index;
+                }else if(colIndex === -1){
+                  colIndex = index
+                }
+              }
+            })
+
+            //if row contans a header with column siblings
+            //remove first child and place it as first separate row in table
+            if(headerIndex !== -1 && colIndex !== -1 && headerIndex < colIndex){
+              console.log("time to do some switching", headerIndex, colIndex);
+              const header = child.children[headerIndex];
+              const headerRow = new Element('tr', {}, [header]);
+
+              removeElement(header);
+              prependChild(element, headerRow);
+            }
+          }
+        })
       }
     };
 

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -351,6 +351,7 @@ export const PostHtmlRenderer = memo(
           code: styles.code,
           li: styles.li,
           p: styles.p,
+          h6: styles.h6
         }}
         domVisitors={{
           onElement: _onElement,

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -282,16 +282,21 @@ export const PostHtmlRenderer = memo(
 
 
     //based on number of columns a table have, sets scroll enabled or disable, also adjust table full width
-    const _tableRenderer = ({ TDefaultRenderer, ...props }: CustomRendererProps<TNode>) => {
-      const tableProps = useHtmlTableProps(props);
+    const _tableRenderer = ({ InternalRenderer, ...props }: CustomRendererProps<TNode>) => {
+      // const tableProps = useHtmlTableProps(props);
 
-      const isScrollable = tableProps.numOfColumns > 3;
-      const _tableWidth = isScrollable ? tableProps.numOfColumns * _minTableColWidth : contentWidth;
+      let maxColumns = 0;
+      props.tnode.children.forEach((child)=>
+        maxColumns = child.children.length > maxColumns ? child.children.length : maxColumns
+      )
+
+      const isScrollable = maxColumns > 3;
+      const _tableWidth = isScrollable ? maxColumns * _minTableColWidth : contentWidth;
       props.style = { width: _tableWidth };
 
       return (
         <ScrollView horizontal={true} scrollEnabled={isScrollable}>
-          <TDefaultRenderer {...props} />
+          <InternalRenderer {...props} />
         </ScrollView>
       )
     }

--- a/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
+++ b/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
@@ -22,6 +22,9 @@ export default EStyleSheet.create({
     alignItems:'center',
     flexWrap:'wrap'
   } as TextStyle,
+  h6:{
+    fontSize:14,
+  } as TextStyle,
   pLi:{
     marginTop:0,
     marginBottom:0

--- a/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
+++ b/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
@@ -36,7 +36,8 @@ export default EStyleSheet.create({
     width: '100%',
     alignSelf:'center',
     marginTop:4,
-    marginBottom:4
+    marginBottom:4,
+    backgroundColor:'red'
   } as ImageStyle,
   th:{
     flex: 1,
@@ -58,6 +59,7 @@ export default EStyleSheet.create({
     borderColor: '$tableBorderColor',
     backgroundColor: '$tableTrColor',
     alignItems:'center',
+    justifyContent:'center',
   } as ViewStyle,
   table:{
       width: '100%',
@@ -82,9 +84,7 @@ export default EStyleSheet.create({
     justifyContent: 'center',
   } as TextStyle,
   phishy:{
-    color:'red',
-    flexDirection:'row', 
-    flexWrap:'wrap'
+    color:'$primaryRed',
   } as TextStyle,
   textJustify:{
     textAlign: Platform.select({ios:'justify', android:'auto'}), //justify with selectable on android causes ends of text getting clipped, 


### PR DESCRIPTION
### What does this PR?
I believe this is the best we can get without having to comprise much on what we have gained during all this time. Honestly I feel so relieved, it took much more time than I expected but I guess it was worth it at the end.

I am doing some dom tempering to make sure if there is a header inline with columns it is place as a separate row instead of affecting rest of columns. Other fix was with column number detection, apparently the useTableProps was failing for inconsistent table columns, fixed that as well.

Also the solution is more generic in nature, it should work for other similar formats in non Actifit posts as well.

![Screenshot 2022-05-11 at 2 43 46 PM](https://user-images.githubusercontent.com/6298342/167820439-3f0072de-de77-4c3d-970c-9045c115814b.png)


### Issue number
fixes #2292 

### Screenshots/Video
Before

https://user-images.githubusercontent.com/6298342/167819810-373f3fb7-2b4f-4f85-9453-d3bc2e7e592a.mov




After

https://user-images.githubusercontent.com/6298342/167819319-2a458971-0d28-4852-a258-24ef5817a392.mov


