### PR TITLE
fixed crash caused by null quotes in coinDetailsScreen

### DIFF
--- a/src/screens/coinDetails/screen/coinDetailsScreen.tsx
+++ b/src/screens/coinDetails/screen/coinDetailsScreen.tsx
@@ -42,7 +42,7 @@ const CoinDetailsScreen = ({ navigation }: CoinDetailsScreenProps) => {
   const globalProps = useAppSelector(state => state.account.globalProps);
   const selectedCoins = useAppSelector(state => state.wallet.selectedCoins);
   const coinData: CoinData = useAppSelector(state => state.wallet.coinsData[coinId]);
-  const quote: QuoteItem = useAppSelector(state => state.wallet.quotes[coinId]);
+  const quote: QuoteItem = useAppSelector(state => state.wallet.quotes ? state.wallet.quotes[coinId] : {});
   const coinActivities: CoinActivitiesCollection = useAppSelector(state => state.wallet.coinsActivities[coinId]);
   const isPinCodeOpen = useAppSelector(state => state.application.isPinCodeOpen);
 


### PR DESCRIPTION
### What does this PR?
First load of wallet was sometimes causing crash, saw a relevant report on bugsnag, I was able to reproduce it by swiftly opening coin details page on new app install.
Bug is now fixed

### Issue number
https://github.com/orgs/ecency/projects/2#card-81825229

https://app.bugsnag.com/ecency/ecency-mobile/errors/62721775f67f41000866b824?filters%5Bevent.since%5D=30d&filters%5Bapp.release_stage%5D=production

