### PR TITLE
skip access token injection if already present

### DIFF
--- a/src/config/ecencyApi.ts
+++ b/src/config/ecencyApi.ts
@@ -38,8 +38,8 @@ api.interceptors.request.use((request) => {
   const digitPinCode = getDigitPinCode(pin);
   const accessToken = decryptKey(token, digitPinCode);
 
-  if (accessToken) {
-    if (!request.data) {
+  if (accessToken && !request.data?.code ) { 
+  if (!request.data){
       request.data = {};
     }
     request.data.code = accessToken;


### PR DESCRIPTION
### What does this PR??
If user had two logged in users, this code was mixing access tokens resulting in a wrong response on other user login.
