### PR TITLE
Sa/orientation locker bug

### DIFF
--- a/src/components/videoPlayer/videoPlayerView.tsx
+++ b/src/components/videoPlayer/videoPlayerView.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Dimensions } from 'react-native';
 import { View, StyleSheet, ActivityIndicator } from 'react-native';
 import WebView from 'react-native-webview';
 import YoutubeIframe, { InitialPlayerParams } from 'react-native-youtube-iframe';
 import Video from 'react-native-video';
 import MediaControls, { PLAYER_STATES } from 'react-native-media-controls';
-import EStyleSheet from 'react-native-extended-stylesheet';
+import Orientation from 'react-native-orientation-locker';
+
 
 interface VideoPlayerProps {
   mode: 'uri' | 'youtube';
@@ -38,6 +39,14 @@ const VideoPlayer = ({
   const [playerState, setPlayerState] = useState(PLAYER_STATES.PAUSED);
   const [screenType, setScreenType] = useState('contain');
 
+  useEffect(() => {
+    if(isFullScreen){
+      Orientation.unlockAllOrientations();
+    } else{
+      Orientation.lockToPortrait();
+    }
+  },[isFullScreen]);
+  
   // react-native-youtube-iframe handlers
   const [shouldPlay, setShouldPlay] = useState(false);
   const _onReady = () => {
@@ -148,6 +157,8 @@ const VideoPlayer = ({
       </View>
     );
   };
+  console.log('isFullScreen : ', isFullScreen);
+  
   return (
     <View style={styles.container}>
       {mode === 'youtube' && youtubeVideoId && (
@@ -160,6 +171,7 @@ const VideoPlayer = ({
             play={shouldPlay}
             onChangeState={_onChangeState}
             onError={_onError}
+            onFullScreenChange={(status) => setIsFullScreen(status)}
           />
         </View>
       )}

--- a/src/screens/post/container/postContainer.js
+++ b/src/screens/post/container/postContainer.js
@@ -28,6 +28,8 @@ const PostContainer = ({ navigation, currentAccount, isLoggedIn, isAnalytics }) 
 
   let author;
 
+  // Commented Orientation Locker causing issues on Android. Can be enabled later
+  /*
   useEffect(() => {
     return () => Orientation.lockToPortrait();
   }, []);
@@ -39,6 +41,7 @@ const PostContainer = ({ navigation, currentAccount, isLoggedIn, isAnalytics }) 
       Orientation.lockToPortrait();
     }
   }, [deviceOrientation]);
+  */
 
   useEffect(() => {
     const { content, permlink, author: _author, isNewPost: _isNewPost } = get(


### PR DESCRIPTION
### What does this PR?

- This PR disbales the landscape lock and unlock and locks screen always to portrait. This would disable landscape but it will atleast do not crashes when landscape is activated in device or app is forced to landscape.
- Second thing it unlocks orientation when video player is set to full screen but this functionality is limited espacially on android. That is because we are using multiple methods to play videos like we are using react-native-video, react-native-webview and react-native-youtube-iframe to play different type of videos. Only react-native-video supports full screen change event and react-native-youtube-iframe partially detects it on android Here is [Issue](https://lonelycpp.github.io/react-native-youtube-iframe/component-props/#onfullscreenchange). In webview we dont have method to detect if it is playing in fullscreen .

- Also it needs more testing for different formats and type of videos and different platforms needs more testing as well.

### Where should the reviewer start?
Go to any post with some video.
Play the video
try to full screen the vide and change device orientation and check if orientation changes or it is fixed to portrait. 
It will show mix behaviour. Static video files should support landscape on both android and iOS. Youtube videos should also support landscape on android. 

### Issue number
https://discord.com/channels/@me/920267778190086205/975297503928926209

### Screenshots/Video
