### PR TITLE
fine tuned reply modal experience

### DIFF
--- a/src/components/quickReplyModal/quickReplyModalStyles.ts
+++ b/src/components/quickReplyModal/quickReplyModalStyles.ts
@@ -16,7 +16,7 @@ export default EStyleSheet.create({
   },
 
   modalContainer: {
-    paddingVertical: 4,
+    paddingTop: 4,
     paddingBottom: Platform.select({
       ios:isIphoneX() ? getBottomSpace() - 20 : 12, 
       android: 20
@@ -42,12 +42,12 @@ export default EStyleSheet.create({
     fontWeight: '500',
   },
   inputContainer: {
-    paddingHorizontal: 16,
-    paddingVertical: 8,
+    paddingVertical: 6,
     height: 120,
   },
   textInput: {
     color: '$primaryBlack',
+    paddingHorizontal:16,
     fontSize: 16,
     flexGrow: 1,
     fontWeight: '500',

--- a/src/components/quickReplyModal/quickReplyModalView.tsx
+++ b/src/components/quickReplyModal/quickReplyModalView.tsx
@@ -32,7 +32,7 @@ const QuickReplyModal = ({ fetchPost }: QuickReplyModalProps, ref) => {
       <ActionSheet
         ref={sheetModalRef}
         gestureEnabled={true}
-        keyboardShouldPersistTaps="handled"
+        keyboardShouldPersistTaps="always"
         containerStyle={styles.sheetContent}
         keyboardHandlerEnabled
         indicatorColor={EStyleSheet.value('$primaryWhiteLightBackground')}


### PR DESCRIPTION
### What does this PR?
- added textinput padding to record cursor tap jump on screen edges
- change keyboard persist tap to always so keyboard stays alive with modal, dismisses on tap outside modal as before.

### Screenshots/Video

https://user-images.githubusercontent.com/6298342/171356321-dc1473fa-7802-42d0-9c67-a0818a295b2e.mov


