### PR TITLE
added separate schedules item in side menu

### DIFF
--- a/src/components/sideMenu/view/sideMenuView.js
+++ b/src/components/sideMenu/view/sideMenuView.js
@@ -22,6 +22,7 @@ import { TextWithIcon } from '../../basicUIElements';
 
 // Constants
 import MENU from '../../../constants/sideMenuItems';
+import ROUTES from '../../../constants/routeNames';
 
 //Utils
 import { getVotingPower } from '../../../utils/manaBar';
@@ -86,6 +87,16 @@ const SideMenuView = ({
     } */
     if (item.id === 'qr') {
       dispatch(toggleQRModal(true));
+      return;
+    }
+
+    if (item.id === 'schedules') {
+      navigateToRoute({
+        routeName: ROUTES.SCREENS.DRAFTS,
+        params: {
+          showSchedules: true,
+        },
+      });
       return;
     }
 

--- a/src/constants/sideMenuItems.js
+++ b/src/constants/sideMenuItems.js
@@ -20,6 +20,12 @@ const authMenuItems = [
     id: 'drafts',
   },
   {
+    name: 'Schedules',
+    route: ROUTES.SCREENS.DRAFTS,
+    icon: 'clock',
+    id: 'schedules',
+  },
+  {
     name: 'Communities',
     route: ROUTES.SCREENS.COMMUNITIES,
     icon: 'people',


### PR DESCRIPTION
### What does this PR?
This PR adds separate item for Schedules in side menu. Upon schedules tap it navigate to draft screen with schedules tab active.

### Issue number
fixes #2337 

### Screenshots/Video

https://user-images.githubusercontent.com/48380998/173107175-326b3db4-a292-4151-bb21-f680095ba25d.mp4


