### PR TITLE
fixed comment cache bug in full editor

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -748,7 +748,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BugsnagReactNative: a96bc039e0e4ec317a8b331714393d836ca60557
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
@@ -759,7 +759,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
   FirebaseMessaging: 5e5118a2383b3531e730d974680954c679ca0a13
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1

--- a/src/components/quickReplyModal/quickReplyModalContent.tsx
+++ b/src/components/quickReplyModal/quickReplyModalContent.tsx
@@ -48,10 +48,11 @@ export const QuickReplyModalContent = ({
 
   const headerText =
     selectedPost && (selectedPost.summary || postBodySummary(selectedPost, 150, Platform.OS as any));
-  const parentAuthor = selectedPost ? selectedPost.author : '';
-  const parentPermlink = selectedPost ? selectedPost.permlink : '';
-  const draftId = `${currentAccount.name}/${parentAuthor}/${parentPermlink}`; //different draftId for each user acount
-
+  let parentAuthor = selectedPost ? selectedPost.author : '';
+  let parentPermlink = selectedPost ? selectedPost.permlink : '';
+  let draftId = `${currentAccount.name}/${parentAuthor}/${parentPermlink}`; //different draftId for each user acount
+  
+  
   useEffect(() => {
     handleCloseRef.current = handleSheetClose;
   }, [commentValue]);
@@ -74,7 +75,7 @@ export const QuickReplyModalContent = ({
 
   // add quick comment value into cache
   const _addQuickCommentIntoCache = (value = commentValue) => {
-
+    
     const quickCommentDraftData: Draft = {
       author: currentAccount.name,
       body: value

--- a/src/components/quickReplyModal/quickReplyModalView.tsx
+++ b/src/components/quickReplyModal/quickReplyModalView.tsx
@@ -37,15 +37,20 @@ const QuickReplyModal = ({ fetchPost }: QuickReplyModalProps, ref) => {
         containerStyle={styles.sheetContent}
         keyboardHandlerEnabled
         indicatorColor={EStyleSheet.value('$primaryWhiteLightBackground')}
-        onClose={() => handleCloseRef.current()}
+        onClose={() => {
+          setSelectedPost(null); //set null on sheet close, causing inconsistant cache bug
+          handleCloseRef.current();
+        }}
       >
-        <QuickReplyModalContent
-          fetchPost={fetchPost}
-          selectedPost={selectedPost}
-          inputRef={inputRef}
-          sheetModalRef={sheetModalRef}
-          handleCloseRef={handleCloseRef}
-        />
+        {selectedPost && (
+          <QuickReplyModalContent
+            fetchPost={fetchPost}
+            selectedPost={selectedPost}
+            inputRef={inputRef}
+            sheetModalRef={sheetModalRef}
+            handleCloseRef={handleCloseRef}
+          />
+        )}
       </ActionSheet>
     </Portal>
   );

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -144,7 +144,7 @@ class EditorContainer extends Component<any, any> {
         });
         if (draftId) {
           this._getStorageDraft(username, isReply, { _id: draftId });
-        }
+        }        
       }
 
       if (navigationParams.isEdit) {


### PR DESCRIPTION
### What does this PR?
This PR fixes a bug in  quick comment cache, when user opens quick comment modal on new post for 1st time it wasn't saving comment cache on correct path.
Because it was getting null value from selectedPost in quickCommentModalContent.  Resetting the value on comment sheet close and with proper null check fixes the issue

### Issue number
https://discord.com/channels/@me/920267778190086205/987579290260484106

### Screen

https://user-images.githubusercontent.com/48380998/174435854-3a866d17-1433-483d-a849-63a48c8b8b47.mp4

shots/Video
