### PR TITLE
Sa/drafts meta

### DIFF
--- a/src/providers/ecency/ecency.ts
+++ b/src/providers/ecency/ecency.ts
@@ -5,7 +5,6 @@ import ecencyApi from '../../config/ecencyApi';
 import { upload } from '../../config/imageApi';
 import serverList from '../../config/serverListApi';
 import { SERVER_LIST } from '../../constants/options/api';
-import { extractMetadata, makeJsonMetadata } from '../../utils/editor';
 import { parsePost } from '../../utils/postParser';
 import { convertCommentHistory, convertLatestQuotes, convertReferral, convertReferralStat } from './converters';
 import { CommentHistoryItem, LatestMarketPrices, ReceivedVestingShare, Referral, ReferralStat } from './ecency.types';
@@ -114,11 +113,10 @@ export const deleteDraft = async (draftId: string) => {
  * @params title
  * @params body
  * @params tags
- * @param thumbIndex
+ * @param meta
  */
-export const addDraft = async (title: string, body: string, tags: string, thumbIndex: number) => {
+export const addDraft = async (title: string, body: string, tags: string, meta: Object) => {
   try {
-    const meta = makeJsonMetadata(extractMetadata(body, thumbIndex), tags)
     const data = { title, body, tags, meta }
     const res = await ecencyApi.post('/private-api/drafts-add', data)
     const { drafts } = res.data;
@@ -139,11 +137,10 @@ export const addDraft = async (title: string, body: string, tags: string, thumbI
  * @params title
  * @params body
  * @params tags
- * @params thumbIndex
+ * @params meta
  */
-export const updateDraft = async (draftId: string, title: string, body: string, tags: string, thumbIndex: number,) => {
+export const updateDraft = async (draftId: string, title: string, body: string, tags: string, meta: Object) => {
   try {
-    const meta = makeJsonMetadata(extractMetadata(body, thumbIndex), tags)
     const data = { id: draftId, title, body, tags, meta }
     const res = await ecencyApi.post(`/private-api/drafts-update`, data)
     if (res.data) {

--- a/src/screens/editor/children/postOptionsModal.tsx
+++ b/src/screens/editor/children/postOptionsModal.tsx
@@ -38,6 +38,7 @@ interface PostOptionsModalProps {
   thumbIndex:number,
   isEdit:boolean;
   isCommunityPost:boolean;
+  rewardType: string;
   handleRewardChange:(rewardType:string)=>void;
   handleThumbSelection:(index:number)=>void;
   handleScheduleChange:(datetime:string|null)=>void;
@@ -50,6 +51,7 @@ const PostOptionsModal =  forwardRef(({
   thumbIndex,
   isEdit,
   isCommunityPost,
+  rewardType,
   handleRewardChange,
   handleThumbSelection,
   handleScheduleChange,
@@ -65,7 +67,6 @@ const PostOptionsModal =  forwardRef(({
     const [disableDone, setDisableDone] = useState(false);
 
     // removed the useeffect causing index reset bug
-
 
     useEffect(()=>{
       if(!scheduleLater){
@@ -84,7 +85,14 @@ const PostOptionsModal =  forwardRef(({
         setShouldReblog(false);
       }
     }, [isCommunityPost])
-  
+
+    // load rewardtype from props if it is already saved in drafts
+    useEffect(() => {
+      if(rewardType){
+        let rewardTypeKey = REWARD_TYPES.findIndex((item) => item.key === rewardType)
+        setRewardTypeIndex(rewardTypeKey);
+      }
+    },[rewardType])
 
     useImperativeHandle(ref, () => ({
         show: () => {

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -86,7 +86,7 @@ class EditorContainer extends Component<any, any> {
   // Component Life Cycle Functions
   componentDidMount() {
     this._isMounted = true;
-    const { currentAccount, navigation } = this.props;
+    const { currentAccount, navigation, dispatch } = this.props;
     const username = currentAccount && currentAccount.name ? currentAccount.name : '';
     let isReply;
     let draftId;
@@ -111,11 +111,14 @@ class EditorContainer extends Component<any, any> {
             thumbIndex: draftThumbIndex,
           })
         }
-        // load beneficiaries and rewards data from meta data of draft
+        // load beneficiaries and rewards data from meta field of draft
         if(_draft.meta && _draft.meta.rewardType){
           this.setState({
             rewardType: _draft.meta.rewardType
           })
+        }
+        if(_draft._id && _draft.meta && _draft.meta.beneficiaries){
+          dispatch(setBeneficiaries(_draft._id || TEMP_BENEFICIARIES_ID, _draft.meta.beneficiaries));
         }
         this.setState({
           draftId: _draft._id,
@@ -1233,8 +1236,6 @@ class EditorContainer extends Component<any, any> {
     } = this.state;
 
     const tags = navigation.state.params && navigation.state.params.tags;
-console.log('this.state.rewardType', this.state.rewardType);
-
     return (
       <EditorScreen
         autoFocusText={autoFocusText}

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -205,7 +205,7 @@ class EditorContainer extends Component<any, any> {
   }
 
   componentDidUpdate(prevProps: Readonly<any>, prevState: Readonly<any>, snapshot?: any): void {
-    if(prevState.rewardType !== this.state.rewardType){
+    if(prevState.rewardType !== this.state.rewardType || prevProps.beneficiariesMap !== this.props.beneficiariesMap){
       // update isDraftSaved when reward type or beneficiaries are changed in post options
       this._handleFormChanged();
     }

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -561,10 +561,15 @@ class EditorContainer extends Component<any, any> {
             tags: fields.tags.join(' '),
           };
         }
-
+        
+        const meta = Object.assign({}, extractMetadata(draftField.body, thumbIndex), {
+          tags: draftField.tags,
+        });
+        const jsonMeta = makeJsonMetadata(meta, draftField.tags);
+        
         //update draft is draftId is present
         if (draftId && draftField && !saveAsNew) {
-          await updateDraft(draftId, draftField.title, draftField.body, draftField.tags, thumbIndex);
+          await updateDraft(draftId, draftField.title, draftField.body, draftField.tags, jsonMeta);
 
           if (this._isMounted) {
             this.setState({
@@ -576,7 +581,7 @@ class EditorContainer extends Component<any, any> {
 
         //create new darft otherwise
         else if (draftField) {
-          const response = await addDraft(draftField.title, draftField.body, draftField.tags, thumbIndex);
+          const response = await addDraft(draftField.title, draftField.body, draftField.tags, jsonMeta);
 
           if (this._isMounted) {
             this.setState({

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -111,7 +111,12 @@ class EditorContainer extends Component<any, any> {
             thumbIndex: draftThumbIndex,
           })
         }
-
+        // load beneficiaries and rewards data from meta data of draft
+        if(_draft.meta && _draft.meta.rewardType){
+          this.setState({
+            rewardType: _draft.meta.rewardType
+          })
+        }
         this.setState({
           draftId: _draft._id,
           isDraft: true,
@@ -1224,9 +1229,11 @@ class EditorContainer extends Component<any, any> {
       onLoadDraftPress,
       thumbIndex,
       uploadProgress,
+      rewardType
     } = this.state;
 
     const tags = navigation.state.params && navigation.state.params.tags;
+console.log('this.state.rewardType', this.state.rewardType);
 
     return (
       <EditorScreen
@@ -1263,6 +1270,7 @@ class EditorContainer extends Component<any, any> {
         thumbIndex={thumbIndex}
         setThumbIndex={this._handleSetThumbIndex}
         uploadProgress={uploadProgress}
+        rewardType={rewardType}
       />
     );
   }

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -199,6 +199,12 @@ class EditorContainer extends Component<any, any> {
     this._isMounted = false;
   }
 
+  componentDidUpdate(prevProps: Readonly<any>, prevState: Readonly<any>, snapshot?: any): void {
+    if(prevState.rewardType !== this.state.rewardType){
+      // update isDraftSaved when reward type or beneficiaries are changed in post options
+      this._handleFormChanged();
+    }
+  }
   _getStorageDraft = async (username, isReply, paramDraft) => {
     const { drafts } = this.props;
 

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -535,7 +535,7 @@ class EditorContainer extends Component<any, any> {
   };
 
   _saveDraftToDB = async (fields, saveAsNew = false) => {
-    const { isDraftSaved, draftId, thumbIndex, isReply } = this.state;
+    const { isDraftSaved, draftId, thumbIndex, isReply, rewardType } = this.state;
     const { currentAccount, dispatch, intl } = this.props;
 
     if (isReply) {
@@ -564,6 +564,8 @@ class EditorContainer extends Component<any, any> {
         
         const meta = Object.assign({}, extractMetadata(draftField.body, thumbIndex), {
           tags: draftField.tags,
+          beneficiaries,
+          rewardType
         });
         const jsonMeta = makeJsonMetadata(meta, draftField.tags);
         

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -373,6 +373,7 @@ class EditorScreen extends Component {
       onLoadDraftPress,
       thumbIndex,
       uploadProgress,
+      rewardType
     } = this.props;
 
     const rightButtonText = intl.formatMessage({
@@ -475,6 +476,7 @@ class EditorScreen extends Component {
           thumbIndex={thumbIndex}
           isEdit={isEdit}
           isCommunityPost={selectedCommunity !== null}
+          rewardType={rewardType}
           handleThumbSelection={this._handleOnThumbSelection}
           handleRewardChange={handleRewardChange}
           handleScheduleChange={this._handleScheduleChange}


### PR DESCRIPTION
### What does this PR?
This PR adds reward type, beneficiaries data in meta field of post draft. 
It loads data from draft meta into post options modal and saves data upon changing in rewards/beneficiaries in post options modal.
This PR can be extended to add any other data as well in meta field of draft.


### Issue number
fixes #2355 

### Screenshots/Video
![image](https://user-images.githubusercontent.com/48380998/174492445-0f78ddf9-3ee5-426c-9f82-e3bbe84d8607.png)
