### PR TITLE
Nt/editing tweaks

### DIFF
--- a/src/components/organisms/inputSupportModal/container/inputSupportModal.tsx
+++ b/src/components/organisms/inputSupportModal/container/inputSupportModal.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { View as AnimatedView } from 'react-native-animatable'
 import { Portal } from 'react-native-portalize';
 import styles from '../children/inputSupportModal.styles';
@@ -22,15 +22,15 @@ export const InputSupportModal = ({children, visible, onClose}: InputSupportModa
             duration={300}
             animation='fadeInUp'>
               <>
-                <View style={styles.container} onTouchEnd={onClose} />
+                <View style={styles.container}  onTouchEnd={onClose} />
                 {
                   Platform.select({
                     ios: (
-                      <KeyboardAvoidingView style={styles.container} behavior="padding">
+                      <KeyboardAvoidingView behavior="padding">
                         {children}
                       </KeyboardAvoidingView>
                     ),
-                    android: <View style={styles.container}>{children}</View>,
+                    android: <View>{children}</View>,
                   })
                 }
 

--- a/src/components/quickReplyModal/quickReplyModalContent.tsx
+++ b/src/components/quickReplyModal/quickReplyModalContent.tsx
@@ -227,11 +227,13 @@ export const QuickReplyModalContent = forwardRef(({
   };
 
 
-  const _deboucedCacheUpdate = useCallback(debounce(_addQuickCommentIntoCache, 500), [])
+  //REMOVED FOR TESTING, CAN BE PUT BACK IF APP STILL CRASHES
+  // const _deboucedCacheUpdate = useCallback(debounce(_addQuickCommentIntoCache, 500), [])
 
   const _onChangeText = (value) => {
     setCommentValue(value);
-    _deboucedCacheUpdate(value)
+    //REMOVED FOR TESTING, CAN BE PUT BACK IF APP STILL CRASHES
+    // _deboucedCacheUpdate(value)
   }
 
 

--- a/src/redux/reducers/cacheReducer.ts
+++ b/src/redux/reducers/cacheReducer.ts
@@ -1,105 +1,105 @@
-import { PURGE_EXPIRED_CACHE, UPDATE_VOTE_CACHE, UPDATE_COMMENT_CACHE, DELETE_COMMENT_CACHE_ENTRY, DELETE_DRAFT_CACHE_ENTRY, UPDATE_DRAFT_CACHE, UPDATE_SUBSCRIBED_COMMUNITY_CACHE, DELETE_SUBSCRIBED_COMMUNITY_CACHE, CLEAR_SUBSCRIBED_COMMUNITIES_CACHE,  } from "../constants/constants";
+import { PURGE_EXPIRED_CACHE, UPDATE_VOTE_CACHE, UPDATE_COMMENT_CACHE, DELETE_COMMENT_CACHE_ENTRY, DELETE_DRAFT_CACHE_ENTRY, UPDATE_DRAFT_CACHE, UPDATE_SUBSCRIBED_COMMUNITY_CACHE, DELETE_SUBSCRIBED_COMMUNITY_CACHE, CLEAR_SUBSCRIBED_COMMUNITIES_CACHE, } from "../constants/constants";
 
 export interface Vote {
-    amount:number;
-    isDownvote:boolean;
-    incrementStep:number;
-    votedAt:number; 
-    expiresAt:number;
+    amount: number;
+    isDownvote: boolean;
+    incrementStep: number;
+    votedAt: number;
+    expiresAt: number;
 }
 
 export interface Comment {
-    author:string,
-    permlink:string,
-    parent_author:string,
-    parent_permlink:string,
-    body?:string,
-    markdownBody:string,
-    author_reputation?:number,
-    total_payout?:number,
-    net_rshares?:number,
-    active_votes?:Array<{rshares:number, voter:string}>,
-    json_metadata?:any,
-    isDeletable?:boolean,
-    created?:string, //handle created and updated separatly
-    updated?:string,
-    expiresAt?:number,
+    author: string,
+    permlink: string,
+    parent_author: string,
+    parent_permlink: string,
+    body?: string,
+    markdownBody: string,
+    author_reputation?: number,
+    total_payout?: number,
+    net_rshares?: number,
+    active_votes?: Array<{ rshares: number, voter: string }>,
+    json_metadata?: any,
+    isDeletable?: boolean,
+    created?: string, //handle created and updated separatly
+    updated?: string,
+    expiresAt?: number,
 }
 
 export interface Draft {
     author: string,
-    body:string,
-    title?:string,
-    tags?:string,
+    body: string,
+    title?: string,
+    tags?: string,
     meta?: any,
-    created?:number,
-    updated?:number,
-    expiresAt?:number;
+    created?: number,
+    updated?: number,
+    expiresAt?: number;
 }
 
 export interface SubscribedCommunity {
     data: Array<any>,
-    expiresAt?:number;
+    expiresAt?: number;
 }
 interface State {
-    votes:Map<string, Vote>
-    comments:Map<string, Comment> //TODO: handle comment array per post, if parent is same
+    votes: Map<string, Vote>
+    comments: Map<string, Comment> //TODO: handle comment array per post, if parent is same
     drafts: Map<string, Draft>
     subscribedCommunities: Map<string, SubscribedCommunity>
-    lastUpdate:{
-        postPath:string,
-        updatedAt:number,
-        type:'vote'|'comment'|'draft',
+    lastUpdate: {
+        postPath: string,
+        updatedAt: number,
+        type: 'vote' | 'comment' | 'draft',
     }
 }
 
-const initialState:State = {
-    votes:new Map(),
-    comments:new Map(),
+const initialState: State = {
+    votes: new Map(),
+    comments: new Map(),
     drafts: new Map(),
     subscribedCommunities: new Map(),
-    lastUpdate:null,
-  };
-  
-  export default function (state = initialState, action) {
-      const {type, payload} = action;
+    lastUpdate: null,
+};
+
+export default function (state = initialState, action) {
+    const { type, payload } = action;
     switch (type) {
         case UPDATE_VOTE_CACHE:
-            if(!state.votes){
+            if (!state.votes) {
                 state.votes = new Map<string, Vote>();
             }
             state.votes.set(payload.postPath, payload.vote);
             return {
                 ...state, //spread operator in requried here, otherwise persist do not register change
-                lastUpdate:{
-                    postPath:payload.postPath,
+                lastUpdate: {
+                    postPath: payload.postPath,
                     updatedAt: new Date().getTime(),
-                    type:'vote',
+                    type: 'vote',
                 }
             };
-        
+
         case UPDATE_COMMENT_CACHE:
-            if(!state.comments){
+            if (!state.comments) {
                 state.comments = new Map<string, Comment>();
             }
             state.comments.set(payload.commentPath, payload.comment);
             return {
                 ...state, //spread operator in requried here, otherwise persist do not register change
-                lastUpdate:{
-                    postPath:payload.commentPath,
+                lastUpdate: {
+                    postPath: payload.commentPath,
                     updatedAt: new Date().getTime(),
-                    type:'comment'
+                    type: 'comment'
                 }
             };
 
         case DELETE_COMMENT_CACHE_ENTRY:
-            if(state.comments && state.comments.has(payload)){
+            if (state.comments && state.comments.has(payload)) {
                 state.comments.delete(payload);
             }
             return { ...state }
-            
+
         case UPDATE_DRAFT_CACHE:
-            if(!state.drafts){
+            if (!state.drafts) {
                 state.drafts = new Map<string, Draft>();
             }
 
@@ -113,12 +113,12 @@ const initialState:State = {
 
             state.drafts.set(payload.id, payloadDraft);
             return {
-              ...state, //spread operator in requried here, otherwise persist do not register change
-              lastUpdate: {
-                postPath: payload.id,
-                updatedAt: new Date().getTime(),
-                type: 'draft',
-              },
+                ...state, //spread operator in requried here, otherwise persist do not register change
+                lastUpdate: {
+                    postPath: payload.id,
+                    updatedAt: new Date().getTime(),
+                    type: 'draft',
+                },
             };
 
         case DELETE_DRAFT_CACHE_ENTRY:
@@ -128,7 +128,7 @@ const initialState:State = {
             return { ...state }
 
         case UPDATE_SUBSCRIBED_COMMUNITY_CACHE:
-            if(!state.subscribedCommunities){
+            if (!state.subscribedCommunities) {
                 state.subscribedCommunities = new Map<string, SubscribedCommunity>();
             }
             const subscribedCommunities = new Map(state.subscribedCommunities);

--- a/src/redux/reducers/cacheReducer.ts
+++ b/src/redux/reducers/cacheReducer.ts
@@ -143,52 +143,52 @@ const initialState:State = {
                 state.subscribedCommunities.delete(payload);
             }
             return { ...state }
-        
+
         case CLEAR_SUBSCRIBED_COMMUNITIES_CACHE:
             state.subscribedCommunities = new Map<string, SubscribedCommunity>();
 
-            return {...state}
-            
+            return { ...state }
+
         case PURGE_EXPIRED_CACHE:
             const currentTime = new Date().getTime();
 
-            if(state.votes && state.votes.size){
-                Array.from(state.votes).forEach((entry)=>{
-                   if(entry[1].expiresAt < currentTime){
-                       state.votes.delete(entry[0]);
-                   }
+            if (state.votes && state.votes.size) {
+                Array.from(state.votes).forEach((entry) => {
+                    if (entry[1].expiresAt < currentTime) {
+                        state.votes.delete(entry[0]);
+                    }
                 })
             }
 
-            if(state.comments && state.comments.size){
-                Array.from(state.comments).forEach((entry)=>{
-                    if(entry[1].expiresAt < currentTime){
+            if (state.comments && state.comments.size) {
+                Array.from(state.comments).forEach((entry) => {
+                    if (entry[1].expiresAt < currentTime) {
                         state.comments.delete(entry[0]);
                     }
-                 })
+                })
             }
 
-            if(state.drafts && state.drafts.size){
-                Array.from(state.drafts).forEach((entry)=>{
-                    if(entry[1].expiresAt < currentTime){
+            if (state.drafts && state.drafts.size) {
+                Array.from(state.drafts).forEach((entry) => {
+                    if (entry[1].expiresAt < currentTime || !entry[1].body) {
                         state.drafts.delete(entry[0]);
                     }
-                 })
+                })
             }
 
-            if(state.subscribedCommunities && state.subscribedCommunities.size){
-                Array.from(state.subscribedCommunities).forEach((entry)=>{
-                    if(entry[1].expiresAt < currentTime){
+            if (state.subscribedCommunities && state.subscribedCommunities.size) {
+                Array.from(state.subscribedCommunities).forEach((entry) => {
+                    if (entry[1].expiresAt < currentTime) {
                         state.subscribedCommunities.delete(entry[0]);
                     }
-                 })
+                })
             }
-            
+
             return {
                 ...state
             }
         default:
-          return state;
-      }
+            return state;
     }
+}
 

--- a/src/redux/reducers/cacheReducer.ts
+++ b/src/redux/reducers/cacheReducer.ts
@@ -174,6 +174,8 @@ export default function (state = initialState, action) {
                         state.drafts.delete(entry[0]);
                     }
                 })
+
+
             }
 
             if (state.subscribedCommunities && state.subscribedCommunities.size) {

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -55,6 +55,7 @@ import { deleteDraftCacheEntry, updateCommentCache, updateDraftCache } from '../
 
 class EditorContainer extends Component<any, any> {
   _isMounted = false;
+  _updatedDraftFields = null;
 
   constructor(props) {
     super(props);
@@ -571,10 +572,9 @@ class EditorContainer extends Component<any, any> {
     const { isDraftSaved, draftId, thumbIndex, isReply, rewardType } = this.state;
     const { currentAccount, dispatch, intl } = this.props;
 
-    //Saves draft locally for both reply and post
-    this._saveCurrentDraft(fields)
 
     if (isReply) { 
+      this._saveCurrentDraft(this._updatedDraftFields)
       return;
     }
 
@@ -658,6 +658,9 @@ class EditorContainer extends Component<any, any> {
           isDraftSaving: false,
           isDraftSaved: false,
         });
+
+        //saves draft locally if remote draft save fails
+        this._saveCurrentDraft(this._updatedDraftFields)
       }
 
       dispatch(
@@ -670,6 +673,10 @@ class EditorContainer extends Component<any, any> {
     }
   };
 
+
+  _updateDraftFields = (fields) => {
+      this._updatedDraftFields = fields;
+  }
 
 
   _saveCurrentDraft = async (fields) => {
@@ -1294,6 +1301,7 @@ class EditorContainer extends Component<any, any> {
         quickReplyText={quickReplyText}
         isUploading={isUploading}
         post={post}
+        updateDraftFields = {this._updateDraftFields}
         saveCurrentDraft={this._saveCurrentDraft}
         saveDraftToDB={this._saveDraftToDB}
         uploadedImage={uploadedImage}
@@ -1309,6 +1317,7 @@ class EditorContainer extends Component<any, any> {
         rewardType={rewardType}
         scheduledForDate={scheduledForDate}
         getBeneficiaries={this._extractBeneficiaries}
+  
       />
     );
   }

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -571,7 +571,10 @@ class EditorContainer extends Component<any, any> {
     const { isDraftSaved, draftId, thumbIndex, isReply, rewardType } = this.state;
     const { currentAccount, dispatch, intl } = this.props;
 
-    if (isReply) {
+    //Saves draft locally for both reply and post
+    this._saveCurrentDraft(fields)
+
+    if (isReply) { 
       return;
     }
 
@@ -667,8 +670,10 @@ class EditorContainer extends Component<any, any> {
     }
   };
 
+
+
   _saveCurrentDraft = async (fields) => {
-    const { draftId, isReply, isEdit, isPostSending, thumbIndex, rewardType, scheduleDate } = this.state;
+    const { draftId, isReply, isEdit, isPostSending } = this.state;
 
     //skip draft save in case post is sending or is post beign edited
     if (isPostSending || isEdit) {
@@ -700,6 +705,10 @@ class EditorContainer extends Component<any, any> {
       dispatch(updateDraftCache(DEFAULT_USER_DRAFT_ID + username, draftField));
     }
   };
+
+
+
+
 
   _submitPost = async ({ fields, scheduleDate }: { fields: any, scheduleDate?: string }) => {
 

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -81,8 +81,8 @@ class EditorScreen extends Component {
   }
 
   componentWillUnmount() {
-    const { isReply, isEdit } = this.props;
-    if (!isReply && !isEdit) {
+    const { isEdit } = this.props;
+    if (!isEdit) {
       this._saveDraftToDB();
     }
   }

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -9,17 +9,11 @@ import { extractMetadata, getWordsCount, makeJsonMetadata } from '../../../utils
 // Components
 import {
   BasicHeader,
-  TitleArea,
-  TagArea,
-  TagInput,
-  SummaryArea,
   PostForm,
   MarkdownEditor,
   SelectCommunityAreaView,
   SelectCommunityModalContainer,
   Modal,
-  UserAvatar,
-  MainButton,
 } from '../../../components';
 
 // dhive
@@ -31,7 +25,6 @@ import globalStyles from '../../../globalStyles';
 import { isCommunity } from '../../../utils/communityValidation';
 
 import styles from './editorScreenStyles';
-import ThumbSelectionModal from '../children/thumbSelectionModal';
 import PostOptionsModal from '../children/postOptionsModal';
 
 class EditorScreen extends Component {
@@ -176,14 +169,15 @@ class EditorScreen extends Component {
   };
 
   _saveCurrentDraft = (fields) => {
-    const { saveCurrentDraft } = this.props;
+    const { saveCurrentDraft, updateDraftFields } = this.props;
 
     if (this.changeTimer) {
       clearTimeout(this.changeTimer);
     }
 
     this.changeTimer = setTimeout(() => {
-      saveCurrentDraft(fields);
+      // saveCurrentDraft(fields);
+      updateDraftFields(fields)
     }, 300);
   };
 
@@ -276,8 +270,8 @@ class EditorScreen extends Component {
     ) {
       console.log('jsonMeta : ', jsonMeta);
       handleFormChanged();
-      //TODO: REMOVED FOR TESTING, CAN BE PUT BACK IF APP STILL CRASHES
-      // this._saveCurrentDraft(fields);
+  
+      this._saveCurrentDraft(fields);
     }
 
     this.setState({ fields }, () => {

--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -276,7 +276,8 @@ class EditorScreen extends Component {
     ) {
       console.log('jsonMeta : ', jsonMeta);
       handleFormChanged();
-      this._saveCurrentDraft(fields);
+      //TODO: REMOVED FOR TESTING, CAN BE PUT BACK IF APP STILL CRASHES
+      // this._saveCurrentDraft(fields);
     }
 
     this.setState({ fields }, () => {


### PR DESCRIPTION
### What does this PR?
This PR removes save to storage as user write feature and saves local drafts when editor is closed... It is indeed a downgrade we should test if this stabilises the app and fixes the crash problem and next try to find a better approach to add save on the go functionality.

I have test this again and again and even tested through automated script for upto 5000 comments in a single app session... no memory problem, no crash showed up. Let's see how things go for melinda

If app still crashes as before for melinda, perhaps we can safely put back the current save on the go functions as well, and look for some other source for crash... but I am quite certain this will fix the issue...