### PR TITLE
Bug Fixed: Header not hiding in login screen when keyboard is active

### DIFF
--- a/src/components/formInput/view/formInputView.tsx
+++ b/src/components/formInput/view/formInputView.tsx
@@ -26,6 +26,7 @@ interface Props extends TextInputProps {
   inputStyle:TextStyle;
   isValid:boolean;
   onChange?:(value:string)=>void;
+  handleFocus?:(value:boolean)=>void;
 }
 
 const FormInputView = ({
@@ -44,6 +45,7 @@ const FormInputView = ({
   isValid,
   value,
   onBlur,
+  handleFocus,
   ...props
 }:Props) => {
   const [_value, setValue] = useState(value || '');
@@ -62,11 +64,16 @@ const FormInputView = ({
 
   const _handleOnFocus = () => {
     setInputBorderColor('#357ce6');
+    if(handleFocus){
+      handleFocus(true);
+    }
   };
 
   const _handleOnBlur = () => {
     setInputBorderColor('#e7e7e7');
-
+    if(handleFocus){
+      handleFocus(false);
+    }
     if (onBlur) {
       onBlur();
     }

--- a/src/components/loginHeader/view/loginHeaderStyles.js
+++ b/src/components/loginHeader/view/loginHeaderStyles.js
@@ -48,6 +48,7 @@ export default EStyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     backgroundColor: '$primaryBackgroundColor',
+    paddingVertical: 8,
   },
   logo: {
     width: 32,

--- a/src/screens/login/screen/loginScreen.js
+++ b/src/screens/login/screen/loginScreen.js
@@ -62,6 +62,9 @@ class LoginScreen extends PureComponent {
     this.setState({ isModalOpen: !isModalOpen });
   };
 
+  _handleFormInputFocus = (isFocused) => {
+    this.setState({ keyboardIsOpen: isFocused });
+  };
   render() {
     const { navigation, intl, handleOnPressLogin, handleSignUp, isLoading } = this.props;
     const { username, isUsernameValid, keyboardIsOpen, password, isModalOpen } = this.state;
@@ -102,8 +105,6 @@ class LoginScreen extends PureComponent {
             style={styles.tabbarItem}
           >
             <KeyboardAwareScrollView
-              onKeyboardWillShow={() => this.setState({ keyboardIsOpen: true })}
-              onKeyboardWillHide={() => this.setState({ keyboardIsOpen: false })}
               enableAutoAutomaticScroll={Platform.OS === 'ios'}
               contentContainerStyle={styles.formWrapper}
               enableOnAndroid={true}
@@ -122,6 +123,7 @@ class LoginScreen extends PureComponent {
                 isFirstImage
                 value={username}
                 inputStyle={styles.input}
+                handleFocus={this._handleFormInputFocus}
               />
               <FormInput
                 rightIconName="lock"
@@ -136,6 +138,7 @@ class LoginScreen extends PureComponent {
                 type="password"
                 numberOfLines={1}
                 inputStyle={styles.input}
+                handleFocus={this._handleFormInputFocus}
               />
               <InformationArea
                 description={intl.formatMessage({


### PR DESCRIPTION
…ctive

### What does this PR?
This PR fixes a bug in login screen which was not hiding header when keyboard is active. The reason behind this bug was onKeyboardWillShow event in react-native-keyboard-aware-scroll-view which was actually triggering keyboard update. But this event method is not supported on android so android was not hiding the header.
The simple fix was instead of using the above event method I had updated the keyboard active status based on input focus/blur.

### Issue number
fixes #2379 

### Screenshots/Video
Tested on iphone 11 simulator, Poco M4 Pro android 11 and Nexus 5 simulator. Nexus 5 simulato screen recording is attached.

https://user-images.githubusercontent.com/48380998/180616108-3c69a223-6d76-4b33-8fbd-df40cc164193.mp4


