### PR TITLE
close snippet modal after selecting snippet

### DIFF
--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -276,6 +276,7 @@ const MarkdownEditorView = ({
       setTextAndSelection: _setTextAndSelection,
       snippetText: `\n${snippetText}\n`,
     });
+    setIsSnippetsOpen(false);
   };
 
   const _handleOnMediaSelect = (mediaArray) => {


### PR DESCRIPTION
### What does this PR?
This PR fixes snippet not inserting bug.
Snippet was adding but the snippet modal was not closing automatically. Fixed the issue by closing modal upon snippet select

### Issue number
fixes #2390 

### Screenshots/Video

https://user-images.githubusercontent.com/48380998/181157189-d741ac65-f6b2-4854-88ba-eb83d22a9d83.mp4


