### PR TITLE
False alarm fix - Token injection failed

### DIFF
--- a/src/config/ecencyApi.ts
+++ b/src/config/ecencyApi.ts
@@ -17,38 +17,41 @@ const api = axios.create({
 
 api.interceptors.request.use((request) => {
   console.log('Starting ecency Request', request);
-  
+
   //skip code addition is register and token refresh endpoint is triggered
-  if(request.url === '/private-api/account-create' 
-    || request.url === '/auth-api/hs-token-refresh' 
+  if (request.url === '/private-api/account-create'
+    || request.url === '/auth-api/hs-token-refresh'
     || request.url === '/private-api/promoted-entries'
     || request.url.startsWith('private-api/leaderboard')
     || request.url.startsWith('/private-api/received-vesting/')
     || request.url.startsWith('/private-api/referrals/')
     || request.url.startsWith('/private-api/market-data')
     || request.url.startsWith('/private-api/comment-history')
-  ){
+  ) {
     return request
   }
 
-  //decrypt access token
-  const state = store.getState();
-  const token = get(state, 'account.currentAccount.local.accessToken');
-  const pin = get(state, 'application.pin');
-  const digitPinCode = getDigitPinCode(pin);
-  const accessToken = decryptKey(token, digitPinCode);
+  if (!request.data?.code) {
+    //if access code not already set, decrypt access token
+    const state = store.getState();
+    const token = get(state, 'account.currentAccount.local.accessToken');
+    const pin = get(state, 'application.pin');
+    const digitPinCode = getDigitPinCode(pin);
+    const accessToken = decryptKey(token, digitPinCode);
 
-  if (accessToken && !request.data?.code ) { 
-  if (!request.data){
-      request.data = {};
+    if (accessToken) {
+      if (!request.data) {
+        request.data = {};
+      }
+      request.data.code = accessToken;
+      console.log('Added access token:', accessToken);
+    } else {
+      const isLoggedIn = state.application.isLoggedIn;
+      console.warn("Failed to inject accessToken", `isLoggedIn:${isLoggedIn}`)
+      bugsnagInstance.notify(new Error(`Failed to inject accessToken in ${request.url} call. isLoggedIn:${isLoggedIn}, local.acccessToken:${token}, pin:${pin}`))
     }
-    request.data.code = accessToken;
-    console.log('Added access token:', accessToken);
-  } else {
-    const isLoggedIn = state.application.isLoggedIn;
-    console.warn("Failed to inject accessToken", `isLoggedIn:${isLoggedIn}`)
-    bugsnagInstance.notify(new Error(`Failed to inject accessToken in ${request.url} call. isLoggedIn:${isLoggedIn}`))
   }
+
 
   return request;
 });


### PR DESCRIPTION
Fixes below behaviour of send false bugsnag report by bypassing access token injection routine if access token is already passed from request initiator routine.

**False alarm source**
![Screenshot 2022-07-28 at 12 12 20 PM](https://user-images.githubusercontent.com/6298342/181444835-57066a02-78d1-4a80-af3f-edb769c8482d.png)

![Screenshot 2022-07-28 at 12 10 06 PM](https://user-images.githubusercontent.com/6298342/181444817-4387ec76-9946-41fb-88a0-f48cfa2df7fd.png)

