### PR TITLE
Nt/theme tweak

### DIFF
--- a/src/components/horizontalIconList/horizontalIconListStyles.js
+++ b/src/components/horizontalIconList/horizontalIconListStyles.js
@@ -33,7 +33,7 @@ export default EStyleSheet.create({
   },
   icon: {
     fontSize: 24,
-    color: '$primaryDarkText',
+    color: '$darkGrayBackground',
   },
   badge: {
     position: 'absolute',

--- a/src/components/toastNotification/view/toastNotificationStyles.js
+++ b/src/components/toastNotification/view/toastNotificationStyles.js
@@ -11,7 +11,7 @@ export default EStyleSheet.create({
     minWidth: '$deviceWidth / 1.9',
     height: 44,
     borderRadius: 30,
-    backgroundColor: '$primaryDarkText',
+    backgroundColor: '$darkGrayBackground',
     margin: 5,
     shadowOffset: {
       height: 5,

--- a/src/screens/coinDetails/children/rangeSelector.tsx
+++ b/src/screens/coinDetails/children/rangeSelector.tsx
@@ -28,7 +28,7 @@ export const RangeSelector = ({range, onRangeChange}:RangeSelectorProps) => {
                 ...styles.rangeOptionWrapper, 
                 backgroundColor: EStyleSheet.value(
                         item.value === range ? 
-                            '$primaryDarkText':'$primaryLightBackground'
+                            '$darkGrayBackground':'$primaryLightBackground'
                     ) 
                 }}>
                 <Text style={{

--- a/src/screens/editor/children/postOptionsModal.tsx
+++ b/src/screens/editor/children/postOptionsModal.tsx
@@ -7,7 +7,6 @@ import styles from './postOptionsModalStyles';
 import ThumbSelectionContent from './thumbSelectionContent';
 import {View as AnimatedView} from 'react-native-animatable';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-import EStyleSheet from 'react-native-extended-stylesheet';
 
 const REWARD_TYPES = [
   {

--- a/src/screens/editor/children/postOptionsModal.tsx
+++ b/src/screens/editor/children/postOptionsModal.tsx
@@ -224,7 +224,7 @@ const PostOptionsModal =  forwardRef(({
         </KeyboardAwareScrollView>
 
         <MainButton
-          style={{...styles.saveButton, backgroundColor:EStyleSheet.value(disableDone?'$primaryDarkGray':'$primaryBlue') }}
+          style={{...styles.saveButton }}
           isDisable={disableDone}
           onPress={_onDonePress}
           text={intl.formatMessage({id:"editor.done"})}

--- a/src/screens/editor/children/postOptionsModalStyles.ts
+++ b/src/screens/editor/children/postOptionsModalStyles.ts
@@ -68,7 +68,6 @@ export default EStyleSheet.create({
         color:'$pureWhite'
     } as TextStyle,
     saveButton:{
-        backgroundColor:'$primaryBlue',
         width:150,
         paddingVertical:16,
         borderRadius:32,

--- a/src/screens/wallet/children/children.styles.ts
+++ b/src/screens/wallet/children/children.styles.ts
@@ -78,7 +78,7 @@ export default EStyleSheet.create({
     backgroundColor: '$primaryBackgroundColor',
   },
   dotStyle: {
-    backgroundColor: '$primaryDarkText',
+    backgroundColor: '$darkGrayBackground',
   },
   chartContainer: {
     height: 112,

--- a/src/themes/darkTheme.js
+++ b/src/themes/darkTheme.js
@@ -8,6 +8,7 @@ export default {
   $primaryLightBackground: '#2e3d51',
   $primaryGrayBackground: '#1e2835',
   $primaryWhiteLightBackground: '#2e3d51',
+  $darkGrayBackground: '#526d91',
   $modalBackground: '#1e2835',
   $white: '#1e2835',
   $black: '#000000',

--- a/src/themes/lightTheme.js
+++ b/src/themes/lightTheme.js
@@ -8,6 +8,7 @@ export default {
   $primaryLightBackground: '#f6f6f6',
   $primaryGrayBackground: '#f5f5f5',
   $primaryWhiteLightBackground: '#ffffff',
+  $darkGrayBackground: '#788187',
   $modalBackground: '#ededed',
   $white: '#FFFFFF',
   $black: '#000000',


### PR DESCRIPTION
### What does this PR?
Updated color theme to have secondary dark gray background

### Issue number
Add an extra task in cards to streamline theme color naming
https://github.com/orgs/ecency/projects/2#card-84954671

### Screenshots/Video
<img width="214" alt="Screenshot 2022-08-13 at 12 52 23 AM" src="https://user-images.githubusercontent.com/6298342/184432923-43f7d4f6-ebc8-4c43-a312-079f931d036e.png">

<img width="220" alt="Screenshot 2022-08-13 at 12 52 57 AM" src="https://user-images.githubusercontent.com/6298342/184433080-c65e8555-e869-4c60-a867-cdffc496cea5.png">

