### PR TITLE
allow all thumbs render in expanded mode

### DIFF
--- a/src/components/uploadsGalleryModal/children/uploadsGalleryContent.tsx
+++ b/src/components/uploadsGalleryModal/children/uploadsGalleryContent.tsx
@@ -317,7 +317,7 @@ const UploadsGalleryContent = ({
         <Animated.View style={{ ...styles.container, height: animatedHeightRef.current }}>
             <FlatList
                 key={isExpandedMode ? 'vertical_grid' : 'horizontal_list'}
-                data={mediaUploads.slice(0, MAX_HORIZONTAL_THUMBS)}
+                data={mediaUploads.slice(0, !isExpandedMode ? MAX_HORIZONTAL_THUMBS:undefined)}
                 keyExtractor={(item) => `item_${item.url}`}
                 renderItem={_renderItem}
                 style={{ flex: 1 }}


### PR DESCRIPTION
### What does this PR?
A small yet important fix for media insertion modal. number of thumbs for expanded mode was also limited to 10 while it should allow all thumbs rendering

This small PR fixes that.

