### PR TITLE
changed walletLineItem icon background to use variable color

### DIFF
--- a/src/components/basicUIElements/view/walletLineItem/walletLineItemView.js
+++ b/src/components/basicUIElements/view/walletLineItem/walletLineItemView.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet';
 
 // Components
 import { DropdownButton, PopoverWrapper, Icon, GrayWrapper } from '../../..';
@@ -38,7 +39,13 @@ const WalletLineItem = ({
               style={[
                 styles.iconWrapper,
                 isCircleIcon && styles.circleIcon,
-                index && { backgroundColor: `${index && index % 2 !== 0 ? 'white' : '#f5f5f5'}` },
+                index && {
+                  backgroundColor: `${
+                    index && index % 2 !== 0
+                      ? EStyleSheet.value('$white')
+                      : EStyleSheet.value('$primaryLightBackground')
+                  }`,
+                },
               ]}
             >
               <Icon style={styles.icon} name={iconName} iconType={iconType} />


### PR DESCRIPTION
### What does this PR?
Changed hard coded icon background color to variable colors used in theme file. It fixes the issue of icons not showing due to same colors of background and icon in dark mode

### Screenshots/Video
![image](https://user-images.githubusercontent.com/48380998/190461992-ab74e0de-bf82-4593-aee7-f9f656dee20d.png)
![image](https://user-images.githubusercontent.com/48380998/190462075-a35a6e15-71dc-4e00-97d8-c5778913325e.png)
