### PR TITLE
Nt/draft fixes

### DIFF
--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -207,7 +207,9 @@ class EditorContainer extends Component<any, any> {
       //if _draft is returned and param draft is available, compare timestamp, use latest
       //if no draft, use result anayways
 
-      if (_localDraft && (!paramDraft || paramDraft.timestamp < _localDraft.updated)) {
+      const _remoteDraftModifiedAt = paramDraft ? new Date(paramDraft.modified).getTime() : 0;
+      const _useLocalDraft = _localDraft && _remoteDraftModifiedAt < _localDraft.updated;
+      if (_useLocalDraft) {
         this.setState({
           draftPost: {
             body: get(_localDraft, 'body', ''),

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -44,6 +44,7 @@ import {
   updateDraftCache,
 } from '../../../redux/actions/cacheActions';
 import QUERIES from '../../../providers/queries/queryKeys';
+import bugsnapInstance from '../../../config/bugsnag';
 
 /*
  *            Props Name        Description                                     Value
@@ -378,8 +379,15 @@ class EditorContainer extends Component<any, any> {
     const { isDraftSaved, draftId, thumbIndex, isReply, rewardType } = this.state;
     const { currentAccount, dispatch, intl, queryClient } = this.props;
 
-    if (isReply) {
+    try {
+      //saves draft locallly
       this._saveCurrentDraft(this._updatedDraftFields);
+    } catch (err) {
+      console.warn('local draft safe failed, skipping for remote only', err);
+      bugsnapInstance.notify(err);
+    }
+
+    if (isReply) {
       return;
     }
 
@@ -469,9 +477,6 @@ class EditorContainer extends Component<any, any> {
           isDraftSaving: false,
           isDraftSaved: false,
         });
-
-        //saves draft locally if remote draft save fails
-        this._saveCurrentDraft(this._updatedDraftFields);
       }
 
       dispatch(

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -73,14 +73,12 @@ class EditorContainer extends Component<any, any> {
       uploadProgress: 0,
       post: null,
       uploadedImage: null,
-      isDraft: false,
       community: [],
       rewardType: 'default',
       sharedSnippetText: null,
       onLoadDraftPress: false,
       thumbIndex: 0,
       shouldReblog: false,
-      failedImageUploads: 0,
     };
   }
 
@@ -107,7 +105,6 @@ class EditorContainer extends Component<any, any> {
 
         this.setState({
           draftId: _draft._id,
-          isDraft: true,
         });
         this._getStorageDraft(username, isReply, _draft);
       }
@@ -179,11 +176,7 @@ class EditorContainer extends Component<any, any> {
     AppState.addEventListener('change', this._handleAppStateChange);
   }
 
-  componentWillUnmount() {
-    AppState.removeEventListener('change', this._handleAppStateChange);
-    this._isMounted = false;
 
-  }
 
   componentDidUpdate(prevProps: Readonly<any>, prevState: Readonly<any>): void {
     if (
@@ -193,6 +186,11 @@ class EditorContainer extends Component<any, any> {
       // update isDraftSaved when reward type or beneficiaries are changed in post options
       this._handleFormChanged();
     }
+  }
+
+  componentWillUnmount() {
+    AppState.removeEventListener('change', this._handleAppStateChange);
+    this._isMounted = false;
   }
 
   _handleAppStateChange = (nextAppState:AppStateStatus) => {
@@ -229,7 +227,6 @@ class EditorContainer extends Component<any, any> {
             body: get(_localDraft, 'body', ''),
             title: get(_localDraft, 'title', ''),
             tags: get(_localDraft, 'tags', '').split(','),
-            isDraft: paramDraft ? true : false,
             draftId: paramDraft ? paramDraft._id : null,
             meta: _localDraft.meta ? _localDraft.meta : null,
           },
@@ -250,7 +247,6 @@ class EditorContainer extends Component<any, any> {
             tags: _tags,
             meta: paramDraft.meta ? paramDraft.meta : null,
           },
-          isDraft: true,
           draftId: paramDraft._id,
         });
 
@@ -361,7 +357,6 @@ class EditorContainer extends Component<any, any> {
         //initilize editor as draft
         this.setState({
           draftId: _draft._id,
-          isDraft: true,
         });
         this._getStorageDraft(username, isReply, _draft);
       };


### PR DESCRIPTION
### What does this PR?
PR fixes essentially three issue I detected with drafts
1. if local draft copy is present in cache, it was being picked no matter the updated remote version
2. if draft is opened from list before draft save is finished on backend, content gets overwritten to previous version
3. if app is closed and open while in editor, user loses updates made from last draft save

### Issue number
https://github.com/orgs/ecency/projects/2#card-85784751

### Screenshots/Video
https://user-images.githubusercontent.com/6298342/191534740-1c2d81e2-0d21-4a37-a105-f0a4796331b8.mov


