### PR TITLE
fixed spacing issue happening on iPhone 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react-native-iap": "^7.5.6",
     "react-native-image-crop-picker": "^0.35.2",
     "react-native-image-zoom-viewer": "^2.2.27",
-    "react-native-iphone-x-helper": "^1.3.1",
+    "react-native-iphone-x-helper": "Norcy/react-native-iphone-x-helper",
     "react-native-keyboard-aware-scroll-view": "^0.9.1",
     "react-native-level-fs": "^3.0.0",
     "react-native-linear-gradient": "^2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8933,7 +8933,11 @@ react-native-image-zoom-viewer@^2.2.27:
   dependencies:
     react-native-image-pan-zoom "^2.1.9"
 
-react-native-iphone-x-helper@^1.0.3, react-native-iphone-x-helper@^1.3.1:
+react-native-iphone-x-helper@Norcy/react-native-iphone-x-helper:
+  version "2.0.0"
+  resolved "https://codeload.github.com/Norcy/react-native-iphone-x-helper/tar.gz/aff3730b2614947a72bcdd86e35ba0217ca1054c"
+
+react-native-iphone-x-helper@^1.0.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
   integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==


### PR DESCRIPTION
### What does this PR?
iPhone 14 was having spacing issue caused by out dated iPhone x helper package. the package is not updated. we can discard this package in favour of react-native-safe-area-context but that require react-native upgrade before we can do that.


### Screenshots/Video
Before
![Screenshot 2022-10-06 at 12 06 25 PM](https://user-images.githubusercontent.com/6298342/194243945-870e1a98-2a82-4a19-badc-99b7d11073c0.png)

After
![Screenshot 2022-10-06 at 12 27 02 PM](https://user-images.githubusercontent.com/6298342/194244084-ce7da004-8a4a-419a-8326-3345b01f0581.png)


