### PR TITLE
[Bug Fix] fixed username autofillbar covering content

### DIFF
--- a/src/components/markdownEditor/styles/markdownEditorStyles.js
+++ b/src/components/markdownEditor/styles/markdownEditorStyles.js
@@ -84,20 +84,10 @@ export default EStyleSheet.create({
       bottom: 56,
     },
   }),
-  searchAccountsContainer: Platform.select({
-    // absolute positioning makes button hide behind keyboard on ios
-    ios: {
-      marginBottom: 12,
-      paddingTop: 8,
-    },
-    // on android the appearing of button was causing momentary glitch with ios variant style
-    android: {
-      // position: 'absolute',
-      // bottom: 56,
-      marginBottom: 12,
-      paddingTop: 8,
-    },
-  }),
+  searchAccountsContainer: {
+    marginBottom: 12,
+    paddingTop: 8,
+  },
   userBubble: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/components/markdownEditor/styles/markdownEditorStyles.js
+++ b/src/components/markdownEditor/styles/markdownEditorStyles.js
@@ -92,8 +92,10 @@ export default EStyleSheet.create({
     },
     // on android the appearing of button was causing momentary glitch with ios variant style
     android: {
-      position: 'absolute',
-      bottom: 56,
+      // position: 'absolute',
+      // bottom: 56,
+      marginBottom: 12,
+      paddingTop: 8,
     },
   }),
   userBubble: {

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -86,6 +86,7 @@ const MarkdownEditorView = ({
   const [showDraftLoadButton, setShowDraftLoadButton] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [insertedMediaUrls, setInsertedMediaUrls] = useState([]);
+  const [isDraftUpdated, setIsDraftupdated] = useState(false);
 
   const inputRef = useRef<any>(null);
   const clearRef = useRef<any>(null);
@@ -204,6 +205,10 @@ const MarkdownEditorView = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const _changeText = useCallback(
     (input) => {
+      // check if draft is just loaded or is updated. Fix for username bar auto loading when draft ends with a username
+      if (draftBody && !isDraftUpdated && draftBody !== input) {
+        setIsDraftupdated(true);
+      }
       bodyText = input;
 
       if (!isEditing) {
@@ -424,11 +429,14 @@ const MarkdownEditorView = ({
     const _innerContent = (
       <>
         {isAndroidOreo() ? _editorWithoutScroll : _editorWithScroll}
-        <UsernameAutofillBar
-          text={bodyText}
-          selection={bodySelection}
-          onApplyUsername={_onApplyUsername}
-        />
+        {isDraftUpdated && (
+          <UsernameAutofillBar
+            text={bodyText}
+            selection={bodySelection}
+            onApplyUsername={_onApplyUsername}
+          />
+        )}
+
         {_renderFloatingDraftButton()}
 
         <EditorToolbar


### PR DESCRIPTION
### What does this PR?
fixed username autofillbar covering content. This is done by applying same style used on ios to android.
Also fixed username bar autoloading when username is present at last of the draft. Added check for draft if draft is loaded then dont show the auto fill bar at start

### Issue number
fixes #2542 

### Screenshots/Video

https://user-images.githubusercontent.com/48380998/207632950-31fe177f-96d7-4f5a-8fa6-e7977061c523.mp4

