### PR TITLE
[Bug Fix] wrong image selection in uploads gallery modal

### DIFF
--- a/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
+++ b/src/components/uploadsGalleryModal/container/uploadsGalleryModal.tsx
@@ -120,6 +120,10 @@ export const UploadsGalleryModal = forwardRef(
       }
     }, [isEditing]);
 
+    useEffect(() => {
+      _getMediaUploads(); // get media uploads when there is new update
+    },[mediaQuery.data]);
+
     const _handleOpenImagePicker = (addToUploads?: boolean) => {
       ImagePicker.openPicker({
         includeBase64: true,


### PR DESCRIPTION
### What does this PR?
This PR fixes image selection bug in uploads gallery modal in editor. When user tries to insert first newly uploaded image it was selecting previous image

### Issue number
https://discord.com/channels/@me/920267778190086205/1056100144199762002

### Screenshots/Video
https://discord.com/channels/@me/920267778190086205/1056239101340307466