### PR TITLE
Nt/drafts cache fixes

### DIFF
--- a/src/components/quickReplyModal/quickReplyModalContent.tsx
+++ b/src/components/quickReplyModal/quickReplyModalContent.tsx
@@ -62,7 +62,7 @@ export const QuickReplyModalContent = forwardRef(
     // load quick comment value from cache
     useEffect(() => {
       let _value = '';
-      if (drafts && drafts.has(draftId) && currentAccount.name === drafts.get(draftId).author) {
+      if (drafts instanceof Map &&  drafts.has(draftId) && currentAccount.name === drafts.get(draftId).author) {
         const quickComment: Draft = drafts.get(draftId);
         _value = quickComment?.body || '';
       }
@@ -183,7 +183,7 @@ export const QuickReplyModalContent = forwardRef(
             );
 
             // delete quick comment draft cache if it exist
-            if (drafts && drafts.has(draftId)) {
+            if (drafts instanceof Map &&  drafts.has(draftId)) {
               dispatch(deleteDraftCacheEntry(draftId));
             }
 

--- a/src/components/quickReplyModal/quickReplyModalContent.tsx
+++ b/src/components/quickReplyModal/quickReplyModalContent.tsx
@@ -56,10 +56,13 @@ export const QuickReplyModalContent = forwardRef(
       },
     }));
 
+
+
+
     // load quick comment value from cache
     useEffect(() => {
       let _value = '';
-      if (drafts.has(draftId) && currentAccount.name === drafts.get(draftId).author) {
+      if (drafts && drafts.has(draftId) && currentAccount.name === drafts.get(draftId).author) {
         const quickComment: Draft = drafts.get(draftId);
         _value = quickComment.body;
       }
@@ -71,6 +74,9 @@ export const QuickReplyModalContent = forwardRef(
         setCommentValue(_value);
       }
     }, [selectedPost]);
+
+
+
 
     // add quick comment value into cache
     const _addQuickCommentIntoCache = (value = commentValue) => {
@@ -177,7 +183,7 @@ export const QuickReplyModalContent = forwardRef(
             );
 
             // delete quick comment draft cache if it exist
-            if (drafts.has(draftId)) {
+            if (drafts && drafts.has(draftId)) {
               dispatch(deleteDraftCacheEntry(draftId));
             }
 

--- a/src/components/quickReplyModal/quickReplyModalContent.tsx
+++ b/src/components/quickReplyModal/quickReplyModalContent.tsx
@@ -64,7 +64,7 @@ export const QuickReplyModalContent = forwardRef(
       let _value = '';
       if (drafts && drafts.has(draftId) && currentAccount.name === drafts.get(draftId).author) {
         const quickComment: Draft = drafts.get(draftId);
-        _value = quickComment.body;
+        _value = quickComment?.body || '';
       }
 
       if (inputRef.current) {

--- a/src/redux/reducers/cacheReducer.ts
+++ b/src/redux/reducers/cacheReducer.ts
@@ -122,7 +122,7 @@ export default function (state = initialState, action) {
       return { ...state };
 
     case UPDATE_DRAFT_CACHE:
-      if (!state.drafts) {
+      if (!(state.drafts instanceof Map)) {
         state.drafts = new Map<string, Draft>();
       }
 

--- a/src/redux/reducers/cacheReducer.ts
+++ b/src/redux/reducers/cacheReducer.ts
@@ -130,7 +130,7 @@ export default function (state = initialState, action) {
       const curDraft = state.drafts.get(payload.id);
       const payloadDraft = payload.draft;
 
-      payloadDraft.created = curDraft ? curDraft.created : curTime;
+      payloadDraft.created = curDraft?.created || curTime;
       payloadDraft.updated = curTime;
       payloadDraft.expiresAt = curTime + 604800000; // 7 days ms
 

--- a/src/redux/reducers/cacheReducer.ts
+++ b/src/redux/reducers/cacheReducer.ts
@@ -145,7 +145,7 @@ export default function (state = initialState, action) {
       };
 
     case DELETE_DRAFT_CACHE_ENTRY:
-      if (state.drafts && state.drafts.has(payload)) {
+      if (state.drafts instanceof Map &&  state.drafts.has(payload)) {
         state.drafts.delete(payload);
       }
       return { ...state };
@@ -206,7 +206,7 @@ export default function (state = initialState, action) {
         });
       }
 
-      if (state.drafts && state.drafts.size) {
+      if (state.drafts instanceof Map &&  state.drafts.size) {
         Array.from(state.drafts).forEach((entry) => {
           if (entry[1].expiresAt < currentTime || !entry[1].body) {
             state.drafts.delete(entry[0]);

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -217,7 +217,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     const { drafts } = this.props;
     if (isReply) {
       const _draft = drafts && drafts.get(paramDraft._id);
-      if (_draft && _draft.body) {
+      if (_draft && !!_draft.body) {
         this.setState({
           draftPost: {
             body: _draft.body,
@@ -233,7 +233,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       // if no draft, use result anayways
 
       const _remoteDraftModifiedAt = paramDraft ? new Date(paramDraft.modified).getTime() : 0;
-      const _useLocalDraft = _localDraft && _remoteDraftModifiedAt < _localDraft.updated;
+      const _useLocalDraft = _remoteDraftModifiedAt < (_localDraft?.updated || 0);
       if (_useLocalDraft) {
         this.setState({
           draftPost: {

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -533,21 +533,16 @@ class EditorContainer extends Component<EditorContainerProps, any> {
 
     const draftField = {
       title: fields.title || '',
-      body: fields.body,
+      body: fields.body || '',
       tags: fields.tags && fields.tags.length > 0 ? fields.tags.toString() : '',
       author: username,
       meta: fields.meta && fields.meta,
     };
 
-    // save reply data
-    if (isReply && draftField.body !== null) {
-      dispatch(updateDraftCache(draftId, draftField));
-
-      // save existing draft data locally
-    } else if (draftId) {
+    // save reply data or save existing draft data locall
+    if (isReply || draftId) {
       dispatch(updateDraftCache(draftId, draftField));
     }
-
     // update editor data locally
     else if (!isReply) {
       dispatch(updateDraftCache(DEFAULT_USER_DRAFT_ID + username, draftField));

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -216,7 +216,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
   _getStorageDraft = async (username, isReply, paramDraft) => {
     const { drafts } = this.props;
     if (isReply) {
-      const _draft = drafts && drafts.get(paramDraft._id);
+      const _draft = drafts instanceof Map &&  drafts.get(paramDraft._id);
       if (_draft && !!_draft.body) {
         this.setState({
           draftPost: {
@@ -227,7 +227,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     } else {
       // TOOD: get draft from redux after reply side is complete
       const _draftId = paramDraft ? paramDraft._id : DEFAULT_USER_DRAFT_ID + username;
-      const _localDraft = drafts && drafts.get(_draftId);
+      const _localDraft = drafts instanceof Map &&  drafts.get(_draftId);
 
       // if _draft is returned and param draft is available, compare timestamp, use latest
       // if no draft, use result anayways
@@ -341,7 +341,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
 
       const remoteDrafts = await getDrafts(username);
 
-      const idLessDraft = drafts && drafts.get(DEFAULT_USER_DRAFT_ID + username);
+      const idLessDraft = drafts instanceof Map && drafts.get(DEFAULT_USER_DRAFT_ID + username);
 
       const loadRecentDraft = () => {
         // if no draft available means local draft is recent

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -216,7 +216,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
   _getStorageDraft = async (username, isReply, paramDraft) => {
     const { drafts } = this.props;
     if (isReply) {
-      const _draft = drafts.get(paramDraft._id);
+      const _draft = drafts && drafts.get(paramDraft._id);
       if (_draft && _draft.body) {
         this.setState({
           draftPost: {
@@ -227,7 +227,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
     } else {
       // TOOD: get draft from redux after reply side is complete
       const _draftId = paramDraft ? paramDraft._id : DEFAULT_USER_DRAFT_ID + username;
-      const _localDraft = drafts.get(_draftId);
+      const _localDraft = drafts && drafts.get(_draftId);
 
       // if _draft is returned and param draft is available, compare timestamp, use latest
       // if no draft, use result anayways
@@ -341,7 +341,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
 
       const remoteDrafts = await getDrafts(username);
 
-      const idLessDraft = drafts.get(DEFAULT_USER_DRAFT_ID + username);
+      const idLessDraft = drafts && drafts.get(DEFAULT_USER_DRAFT_ID + username);
 
       const loadRecentDraft = () => {
         // if no draft available means local draft is recent


### PR DESCRIPTION
### What does this PR?
After assessing loopholes that might have caused comments to crash app I was able to force reproduce a scenario that Melinda faced i.e. crashing comments got fixed after publishing a previously saved draft.

This is a blind code that might resolve the issue, I will be further assessing the making changes to the drafts cache flow but this can be used as a hotfix
