### PR TITLE
removed bottom margin from voters screen

### DIFF
--- a/src/components/votersDisplay/view/votersDisplayStyles.js
+++ b/src/components/votersDisplay/view/votersDisplayStyles.js
@@ -4,7 +4,6 @@ export default EStyleSheet.create({
   container: {
     flex: 1,
     padding: 8,
-    marginBottom: 40,
     flexDirection: 'row',
     height: '$deviceHeight - 150',
     backgroundColor: '$primaryBackgroundColor',


### PR DESCRIPTION
### What does this PR?
This PR fixes the white bottom bar issue on voters screen
For android navigation bar there is no straight forward to change its color. Some packages are available which can change the bottom navigation bar background color like https://www.npmjs.com/package/react-native-system-navigation-bar
### Issue number
https://discord.com/channels/@me/920267778190086205/1065345008871407666

### Screenshots/Video
<img width="323" alt="image" src="https://user-images.githubusercontent.com/48380998/213533401-a5b274f6-379e-4a59-9e08-343d9c1ada6e.png">
