### PR TITLE
remove <span> tags from post content

### DIFF
--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -41,7 +41,11 @@ export const PostHtmlRenderer = memo(
     const postImgUrlsRef = useRef<string[]>([]);
 
     // new renderer functions
-    body = body.replace(/<center>/g, '<div class="text-center">').replace(/<\/center>/g, '</div>');
+    body = body
+      .replace(/<center>/g, '<div class="text-center">')
+      .replace(/<\/center>/g, '</div>')
+      .replace(/<span>/g, '')
+      .replace(/<\/span>/g, '');
 
     console.log('Comment body:', body);
 


### PR DESCRIPTION
### What does this PR?
apparently renderHtml was not treating <span> well if <a> is used inside the and was causing a glitch. since we do not exclusively handle <span> in our mobile side rendering, removing <span> fixed the issue without causing any render differences.

let me know what you think.

### Screenshots/Video
<img width="213" alt="Screenshot 2023-02-04 at 10 24 11 PM" src="https://user-images.githubusercontent.com/6298342/216781176-d7dcd37b-625a-4ccc-830a-3a83fda98519.png">

