### PR TITLE
Allow purchase only for account purchase without login

### DIFF
--- a/src/containers/inAppPurchaseContainer.tsx
+++ b/src/containers/inAppPurchaseContainer.tsx
@@ -254,8 +254,17 @@ class InAppPurchaseContainer extends Component {
   };
 
   _buyItem = async (sku) => {
-    const { navigation } = this.props;
+    const { navigation, isLoggedIn, intl } = this.props;
     const { unconsumedPurchases } = this.state;
+    // if user is not loggedIn and purchase is other than account purchase
+    // add more skus here for account purchase
+    if (!isLoggedIn && sku !== '999accounts') {
+      Alert.alert(
+        intl.formatMessage({ id: 'login.not_loggedin_alert' }),
+        intl.formatMessage({ id: 'login.not_loggedin_alert_desc' }),
+      );
+      return;
+    }
 
     if (sku !== 'freePoints') {
       this.setState({ isProcessing: true });
@@ -363,6 +372,7 @@ class InAppPurchaseContainer extends Component {
 
 const mapStateToProps = (state) => ({
   currentAccount: state.account.currentAccount,
+  isLoggedIn: state.application.isLoggedIn,
 });
 
 const mapHooksToProps = (props) => {


### PR DESCRIPTION
### What does this PR?
Only allow account purchase when user is not logged in. 
All other purchases are disabled when not logged in

### Issue number
https://discord.com/channels/@me/920267778190086205/1079028003515924500

### Screenshots/Video

https://user-images.githubusercontent.com/48380998/221628035-e15aab3e-8577-4a57-90b7-82ef91153f8d.mp4

