### PR TITLE
Nt/flatlist optimise

### DIFF
--- a/src/components/postComments/container/postComments.tsx
+++ b/src/components/postComments/container/postComments.tsx
@@ -315,6 +315,10 @@ const PostComments = forwardRef(
           onContentSizeChange={_onContentSizeChange}
           renderItem={_renderItem}
           keyExtractor={(item) => `${item.author}/${item.permlink}`}
+          initialNumToRender={6}
+          maxToRenderPerBatch={6}
+          updateCellsBatchingPeriod={100}
+          windowSize={13}
           refreshControl={
             <RefreshControl
               refreshing={discussionQuery.isFetching}

--- a/src/components/postsList/container/postsListContainer.tsx
+++ b/src/components/postsList/container/postsListContainer.tsx
@@ -272,7 +272,6 @@ const postsListContainer = (
         showsVerticalScrollIndicator={false}
         renderItem={_renderItem}
         keyExtractor={(content, index) => `${content.author}/${content.permlink}-${index}`}
-        removeClippedSubviews
         onEndReachedThreshold={1}
         maxToRenderPerBatch={5}
         initialNumToRender={3}


### PR DESCRIPTION
### What does this PR?
Optimised and tested feed and comments flatlists.

- Reduced rendering load to roughly half while processing post comments.
- On some ios devices (iPhone X) often times some of feed list items were being unresponsive, issue seems to have been fixed by removing prop `removeClippedSubview` though tested well afterwards yet need more testing after TestFlight versions is available.

### Issue number
https://github.com/orgs/ecency/projects/2#card-87963367

