### PR TITLE
Nt/img cache optimise

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -575,7 +575,7 @@ PODS:
     - React-Core
   - RNDeviceInfo (10.2.1):
     - React-Core
-  - RNFastImage (8.6.1):
+  - RNFastImage (8.6.3):
     - React-Core
     - SDWebImage (~> 5.11.1)
     - SDWebImageWebPCoder (~> 0.8.4)
@@ -1079,7 +1079,7 @@ SPEC CHECKSUMS:
   RNCClipboard: 2834e1c4af68697089cdd455ee4a4cdd198fa7dd
   RNCPushNotificationIOS: 87b8d16d3ede4532745e05b03c42cff33a36cc45
   RNDeviceInfo: c31137f22ee779fe3931d1a8d60cc1af80ef4077
-  RNFastImage: 3207b9eb17c2425d574ca40db35185db6e324f4e
+  RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
   RNFBAnalytics: ea1421b49a0bf5e5bb7274df4a330713d0e85d2e
   RNFBApp: e4439717c23252458da2b41b81b4b475c86f90c4
   RNFBDynamicLinks: 538840f6e3f58511f857d15df1bc25ed655dc283

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "react-native-dynamic": "^1.0.0",
     "react-native-email-link": "^1.14.3",
     "react-native-extended-stylesheet": "^0.10.0",
-    "react-native-fast-image": "^8.3.2",
+    "react-native-fast-image": "^8.6.3",
     "react-native-fingerprint-scanner": "hieuvp/react-native-fingerprint-scanner",
     "react-native-flipper": "^0.164.0",
     "react-native-gesture-handler": "^2.9.0",

--- a/src/screens/application/hook/useInitApplication.tsx
+++ b/src/screens/application/hook/useInitApplication.tsx
@@ -26,6 +26,7 @@ import { markNotifications } from '../../../providers/ecency/ecency';
 import { updateUnreadActivityCount } from '../../../redux/actions/accountAction';
 import RootNavigation from '../../../navigation/rootNavigation';
 import ROUTES from '../../../constants/routeNames';
+import FastImage from 'react-native-fast-image';
 
 export const useInitApplication = () => {
   const dispatch = useAppDispatch();
@@ -35,6 +36,7 @@ export const useInitApplication = () => {
 
   const appState = useRef(AppState.currentState);
   const appStateSubRef = useRef<NativeEventSubscription | null>(null);
+  const lowMemSubRef = useRef<NativeEventSubscription | null>(null);
 
   const notifeeEventRef = useRef<any>(null);
   const messagingEventRef = useRef<any>(null);
@@ -57,6 +59,7 @@ export const useInitApplication = () => {
     BackgroundTimer.start(); // ref: https://github.com/ocetnik/react-native-background-timer#ios
 
     appStateSubRef.current = AppState.addEventListener('change', _handleAppStateChange);
+    lowMemSubRef.current = AppState.addEventListener('memoryWarning', _handleLowMemoryWarning)
 
     // check for device landscape status and lcok orientation accordingly. Fix for orientation bug on android tablet devices
     isLandscape().then((isLandscape) => {
@@ -91,6 +94,10 @@ export const useInitApplication = () => {
   const _cleanup = () => {
     if (appStateSubRef.current) {
       appStateSubRef.current.remove();
+    }
+
+    if (lowMemSubRef.current){
+      lowMemSubRef.current.remove();
     }
 
     if (notifeeEventRef.current) {
@@ -141,6 +148,11 @@ export const useInitApplication = () => {
 
     appState.current = nextAppState;
   };
+
+
+  const _handleLowMemoryWarning = () => {
+    FastImage.clearMemoryCache();
+  }
 
   const _pushNavigate = (notification) => {
     let params = null;

--- a/src/screens/post/screen/postScreen.tsx
+++ b/src/screens/post/screen/postScreen.tsx
@@ -7,6 +7,7 @@ import styles from '../styles/postScreen.styles';
 
 // Component
 import { postQueries } from '../../../providers/queries';
+import FastImage from 'react-native-fast-image';
 
 const PostScreen = ({ route }) => {
   const params = route.params || {};
@@ -20,6 +21,13 @@ const PostScreen = ({ route }) => {
 
   const getPostQuery = postQueries.useGetPostQuery(author, permlink, params.content);
   const getParentPostQuery = postQueries.useGetPostQuery();
+
+  useEffect(()=>{
+    return () => {
+      //clears FastImage RAM, not disk usage;
+      FastImage.clearMemoryCache();
+    }
+  },[])
 
   useEffect(() => {
     const post = getPostQuery.data;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9191,10 +9191,10 @@ react-native-extended-stylesheet@^0.10.0:
     css-mediaquery "^0.1.2"
     object-resolve-path "^1.1.0"
 
-react-native-fast-image@^8.3.2:
-  version "8.6.1"
-  resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.6.1.tgz#6a3a11b8ebc7629919265d33a420a04d13c897e0"
-  integrity sha512-ILuP7EuakqHNzTr8ZbumhuxG4tE/wGQ66z4nEEuzc0FlqY6rYaPsnq/UD2ahoyFj6QP1WvA2RIK3odib+VcqWg==
+react-native-fast-image@^8.6.3:
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.6.3.tgz#6edc3f9190092a909d636d93eecbcc54a8822255"
+  integrity sha512-Sdw4ESidXCXOmQ9EcYguNY2swyoWmx53kym2zRsvi+VeFCHEdkO+WG1DK+6W81juot40bbfLNhkc63QnWtesNg==
 
 react-native-fingerprint-scanner@hieuvp/react-native-fingerprint-scanner:
   version "6.0.0"


### PR DESCRIPTION
### What does this PR?
- clears image memory on memoryWarning generated, will handle warnings made if feed cache goes beyond limits
- clears image memory coming back from post screen, handles instant memory clearing when post screen unmount, apparently this does not affected images already displayed on screen and re-rendering of posts picks image from disk cache.