### PR TITLE
disable selectable html text to fix zooming issue

### DIFF
--- a/src/components/postComments/container/postComments.tsx
+++ b/src/components/postComments/container/postComments.tsx
@@ -69,6 +69,8 @@ const PostComments = forwardRef(
     const [selectedOptionIndex, setSelectedOptionIndex] = useState(0);
     const [headerHeight, setHeaderHeight] = useState(0);
 
+    const [refreshing, setRefreshing] = useState(false);
+
 
     const sortedSections = useMemo(
       () => sortComments(selectedFilter, discussionQuery.sectionedData),
@@ -94,10 +96,12 @@ const PostComments = forwardRef(
     useEffect(() => {
       if (!discussionQuery.isLoading) {
         handleOnCommentsLoaded();
+        setRefreshing(false);
       }
     }, [discussionQuery.isLoading]);
 
     const _onRefresh = () => {
+      setRefreshing(true);
       discussionQuery.refetch();
       onRefresh();
     };
@@ -321,7 +325,7 @@ const PostComments = forwardRef(
           windowSize={13}
           refreshControl={
             <RefreshControl
-              refreshing={discussionQuery.isFetching}
+              refreshing={refreshing}
               onRefresh={_onRefresh}
               progressBackgroundColor="#357CE6"
               tintColor={!isDarkTheme ? '#357ce6' : '#96c0ff'}

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -388,7 +388,7 @@ export const PostHtmlRenderer = memo(
         renderers={renderers}
         onHTMLLoaded={onLoaded && onLoaded}
         defaultTextProps={{
-          selectable: true,
+          selectable: false,
         }}
         customHTMLElementModels={customHTMLElementModels}
         renderersProps={renderersProps}


### PR DESCRIPTION
### What does this PR?
selectable html enabled used along inital lottie loading animation is causing an anamoly to cause zooming issue, very very weird.

As a workaround removed selectable prop for release, it should not offend users because selectable do not perfectly work anyways but will find some solution later.

