### PR TITLE
Nt/account switch fix

### DIFF
--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -92,6 +92,10 @@ const AccountsBottomSheetContainer = ( ) => {
       const realmData = await getUserDataWithUsername(accountData.username);
 
       _currentAccount.username = _currentAccount.name;
+
+      if(!realmData[0]){
+        throw new Error("Auth data expired, functionality may be affected, logout suggested");
+      }
       _currentAccount.local = realmData[0];
 
       // migreate account to use access token for master key auth type

--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -94,7 +94,7 @@ const AccountsBottomSheetContainer = ( ) => {
       _currentAccount.username = _currentAccount.name;
 
       if(!realmData[0]){
-        throw new Error("Auth data expired, functionality may be affected, logout suggested");
+        throw new Error(intl.formatMessage({ id: 'alert.auth_expired' }));
       }
       _currentAccount.local = realmData[0];
 

--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -1,26 +1,16 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import React, { useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { Alert } from 'react-native';
 import { useIntl } from 'react-intl';
 import RootNavigation from '../../../navigation/rootNavigation';
 
-import { removeOtherAccount, updateCurrentAccount } from '../../../redux/actions/accountAction';
-import {
-  isPinCodeOpen,
-  isRenderRequired,
-  login,
-  logout,
-  logoutDone,
-} from '../../../redux/actions/applicationActions';
+import { updateCurrentAccount } from '../../../redux/actions/accountAction';
+
 
 import {
   getUserDataWithUsername,
-  removeAllUserData,
-  removePinCode,
-  setAuthStatus,
-  setExistUser,
-  setPinCodeOpen,
+
 } from '../../../realm/realm';
 import {
   migrateToMasterKeyWithAccessToken,
@@ -29,12 +19,12 @@ import {
 } from '../../../providers/hive/auth';
 
 import AccountsBottomSheet from '../view/accountsBottomSheetView';
-import { toggleAccountsBottomSheet } from '../../../redux/actions/uiAction';
+import { logout, toggleAccountsBottomSheet } from '../../../redux/actions/uiAction';
 
 // Constants
 import AUTH_TYPE from '../../../constants/authType';
 import { getDigitPinCode, getMutes } from '../../../providers/hive/dhive';
-import { setFeedPosts, setInitPosts } from '../../../redux/actions/postsAction';
+
 import { useAppSelector } from '../../../hooks';
 import { getUnreadNotificationCount } from '../../../providers/ecency/ecency';
 import { decryptKey } from '../../../utils/crypto';
@@ -42,7 +32,7 @@ import { getPointsSummary } from '../../../providers/ecency/ePoint';
 import { fetchSubscribedCommunities } from '../../../redux/actions/communitiesAction';
 import { clearSubscribedCommunitiesCache } from '../../../redux/actions/cacheActions';
 
-const AccountsBottomSheetContainer = ({ navigation }) => {
+const AccountsBottomSheetContainer = ( ) => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const accountsBottomSheetViewRef = useRef();

--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -90,16 +90,19 @@ const AccountsBottomSheetContainer = () => {
 
       _currentAccount.username = _currentAccount.name;
 
-      if (realmData[0]) {
-        // throw new Error(intl.formatMessage({ id: 'alert.auth_expired' }));
+      if (!realmData[0]) {
+        // keys data corrupted, ask user to verify login
         dispatch(showActionModal({
           title:intl.formatMessage({ id: 'alert.warning' }),
           body:intl.formatMessage({ id: 'alert.auth_expired' }),
           buttons:[{
-            text: intl.formatMessage({ id: 'alert.cancel' }), style: 'destructive' ,
+            text: intl.formatMessage({ id: 'alert.cancel' }), 
+            style: 'destructive' ,
+            onPress: ()=>{},
          },
          {
-            text: intl.formatMessage({ id: 'alert.verify' }), onPress: () => _navigateToRoute(ROUTES.SCREENS.LOGIN, {username:accountData.username}) ,
+            text: intl.formatMessage({ id: 'alert.verify' }), 
+            onPress: () => _navigateToRoute(ROUTES.SCREENS.LOGIN, {username:accountData.username}) ,
           },]
         }))
         return;

--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -7,11 +7,7 @@ import RootNavigation from '../../../navigation/rootNavigation';
 
 import { updateCurrentAccount } from '../../../redux/actions/accountAction';
 
-
-import {
-  getUserDataWithUsername,
-
-} from '../../../realm/realm';
+import { getUserDataWithUsername } from '../../../realm/realm';
 import {
   migrateToMasterKeyWithAccessToken,
   refreshSCToken,
@@ -32,7 +28,7 @@ import { getPointsSummary } from '../../../providers/ecency/ePoint';
 import { fetchSubscribedCommunities } from '../../../redux/actions/communitiesAction';
 import { clearSubscribedCommunitiesCache } from '../../../redux/actions/cacheActions';
 
-const AccountsBottomSheetContainer = ( ) => {
+const AccountsBottomSheetContainer = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const accountsBottomSheetViewRef = useRef();
@@ -93,7 +89,7 @@ const AccountsBottomSheetContainer = ( ) => {
 
       _currentAccount.username = _currentAccount.name;
 
-      if(!realmData[0]){
+      if (!realmData[0]) {
         throw new Error(intl.formatMessage({ id: 'alert.auth_expired' }));
       }
       _currentAccount.local = realmData[0];

--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../../providers/hive/auth';
 
 import AccountsBottomSheet from '../view/accountsBottomSheetView';
-import { logout, toggleAccountsBottomSheet } from '../../../redux/actions/uiAction';
+import { logout, showActionModal, toggleAccountsBottomSheet } from '../../../redux/actions/uiAction';
 
 // Constants
 import AUTH_TYPE from '../../../constants/authType';
@@ -27,6 +27,7 @@ import { decryptKey } from '../../../utils/crypto';
 import { getPointsSummary } from '../../../providers/ecency/ePoint';
 import { fetchSubscribedCommunities } from '../../../redux/actions/communitiesAction';
 import { clearSubscribedCommunitiesCache } from '../../../redux/actions/cacheActions';
+import ROUTES from '../../../constants/routeNames';
 
 const AccountsBottomSheetContainer = () => {
   const intl = useIntl();
@@ -46,11 +47,11 @@ const AccountsBottomSheetContainer = () => {
     }
   }, [isVisibleAccountsBottomSheet]);
 
-  const _navigateToRoute = (name = null) => {
+  const _navigateToRoute = (name:string, params:any) => {
     dispatch(toggleAccountsBottomSheet(false));
     accountsBottomSheetViewRef.current?.closeAccountsBottomSheet();
     if (name) {
-      RootNavigation.navigate({ name });
+      RootNavigation.navigate({ name, params });
     }
   };
 
@@ -89,8 +90,19 @@ const AccountsBottomSheetContainer = () => {
 
       _currentAccount.username = _currentAccount.name;
 
-      if (!realmData[0]) {
-        throw new Error(intl.formatMessage({ id: 'alert.auth_expired' }));
+      if (realmData[0]) {
+        // throw new Error(intl.formatMessage({ id: 'alert.auth_expired' }));
+        dispatch(showActionModal({
+          title:intl.formatMessage({ id: 'alert.warning' }),
+          body:intl.formatMessage({ id: 'alert.auth_expired' }),
+          buttons:[{
+            text: intl.formatMessage({ id: 'alert.cancel' }), style: 'destructive' ,
+         },
+         {
+            text: intl.formatMessage({ id: 'alert.verify' }), onPress: () => _navigateToRoute(ROUTES.SCREENS.LOGIN, {username:accountData.username}) ,
+          },]
+        }))
+        return;
       }
       _currentAccount.local = realmData[0];
 

--- a/src/components/accountsBottomSheet/view/accountsBottomSheetStyles.js
+++ b/src/components/accountsBottomSheet/view/accountsBottomSheetStyles.js
@@ -24,7 +24,8 @@ export default EStyleSheet.create({
     backgroundColor: 'yellow',
   },
   textButton: {
-    color: '$primaryDarkBlue',
+    color: '$primaryDarkGray',
+    fontWeight:'700',
     fontSize: 16,
     paddingVertical: 16,
     paddingHorizontal: 16,
@@ -43,6 +44,6 @@ export default EStyleSheet.create({
   button: {
     justifyContent: 'center',
     backgroundColor: 'transparent',
-    height: 50,
+    paddingVertical: 4,
   },
 });

--- a/src/components/accountsBottomSheet/view/accountsBottomSheetStyles.js
+++ b/src/components/accountsBottomSheet/view/accountsBottomSheetStyles.js
@@ -25,7 +25,7 @@ export default EStyleSheet.create({
   },
   textButton: {
     color: '$primaryDarkGray',
-    fontWeight:'700',
+    fontWeight: '700',
     fontSize: 16,
     paddingVertical: 16,
     paddingHorizontal: 16,

--- a/src/components/accountsBottomSheet/view/accountsBottomSheetView.js
+++ b/src/components/accountsBottomSheet/view/accountsBottomSheetView.js
@@ -30,6 +30,7 @@ const AccountsBottomSheet = forwardRef(
         bottomSheetModalRef.current?.setModalVisible(false);
       },
     }));
+    
 
     // _handlePressAccountTile(item)
     const _renderAccountTile = ({ item }) => (
@@ -70,7 +71,7 @@ const AccountsBottomSheet = forwardRef(
           />
           <Separator style={styles.separator} />
           <View style={{ paddingBottom: insets.bottom + 16 }}>
-            <TouchableWithoutFeedback
+            <TouchableOpacity
               style={styles.button}
               onPress={() => navigateToRoute(ROUTES.SCREENS.REGISTER)}
             >
@@ -79,9 +80,9 @@ const AccountsBottomSheet = forwardRef(
                   {intl.formatMessage({ id: 'side_menu.create_a_new_account' })}
                 </Text>
               </View>
-            </TouchableWithoutFeedback>
+            </TouchableOpacity>
             <Separator style={styles.separator} />
-            <TouchableWithoutFeedback
+            <TouchableOpacity
               style={styles.button}
               onPress={() => navigateToRoute(ROUTES.SCREENS.LOGIN)}
             >
@@ -90,7 +91,7 @@ const AccountsBottomSheet = forwardRef(
                   {intl.formatMessage({ id: 'side_menu.add_an_existing_account' })}
                 </Text>
               </View>
-            </TouchableWithoutFeedback>
+            </TouchableOpacity>
             <Separator style={styles.separator} />
           </View>
         </ActionSheet>

--- a/src/components/accountsBottomSheet/view/accountsBottomSheetView.js
+++ b/src/components/accountsBottomSheet/view/accountsBottomSheetView.js
@@ -1,6 +1,5 @@
-import React, { useCallback, useMemo, useRef, forwardRef, useImperativeHandle } from 'react';
+import React, { useRef, forwardRef, useImperativeHandle } from 'react';
 import { View, Text, TouchableWithoutFeedback, TouchableOpacity } from 'react-native';
-import { useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import ActionSheet from 'react-native-actions-sheet';
 import EStyleSheet from 'react-native-extended-stylesheet';
@@ -8,18 +7,16 @@ import EStyleSheet from 'react-native-extended-stylesheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { FlatList } from 'react-native-gesture-handler';
-import { toggleAccountsBottomSheet } from '../../../redux/actions/uiAction';
 
-import { UserAvatar, Icon, TextButton, Separator } from '../../index';
+import { UserAvatar, Icon, Separator } from '../../index';
 
 import { default as ROUTES } from '../../../constants/routeNames';
 
 import styles from './accountsBottomSheetStyles';
-import { switchAccount } from '../../../providers/hive/auth';
 
 const AccountsBottomSheet = forwardRef(
   ({ accounts, currentAccount, navigateToRoute, switchAccount, onClose }, ref) => {
-    const dispatch = useDispatch();
+
     const bottomSheetModalRef = useRef();
     const userList = useRef();
     const insets = useSafeAreaInsets();

--- a/src/components/accountsBottomSheet/view/accountsBottomSheetView.js
+++ b/src/components/accountsBottomSheet/view/accountsBottomSheetView.js
@@ -16,7 +16,6 @@ import styles from './accountsBottomSheetStyles';
 
 const AccountsBottomSheet = forwardRef(
   ({ accounts, currentAccount, navigateToRoute, switchAccount, onClose }, ref) => {
-
     const bottomSheetModalRef = useRef();
     const userList = useRef();
     const insets = useSafeAreaInsets();
@@ -30,7 +29,6 @@ const AccountsBottomSheet = forwardRef(
         bottomSheetModalRef.current?.setModalVisible(false);
       },
     }));
-    
 
     // _handlePressAccountTile(item)
     const _renderAccountTile = ({ item }) => (

--- a/src/components/actionModal/view/actionModalView.tsx
+++ b/src/components/actionModal/view/actionModalView.tsx
@@ -3,10 +3,10 @@ import { View, Text } from 'react-native';
 import FastImage from 'react-native-fast-image';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import ActionSheet from 'react-native-actions-sheet';
-import { TextButton } from '../../buttons';
 import styles from './actionModalStyles';
 
 import { ActionModalData } from '../container/actionModalContainer';
+import { MainButton } from '../../mainButton';
 
 export interface ActionModalRef {
   showModal: () => void;
@@ -57,7 +57,7 @@ const ActionModalView = ({ onClose, data }: ActionModalViewProps, ref) => {
       <View style={styles.actionPanel}>
         {buttons ? (
           buttons.map((props) => (
-            <TextButton
+            <MainButton
               key={props.text}
               text={props.text}
               onPress={(evn) => {
@@ -69,7 +69,7 @@ const ActionModalView = ({ onClose, data }: ActionModalViewProps, ref) => {
             />
           ))
         ) : (
-          <TextButton
+          <MainButton
             key="default"
             text="OK"
             onPress={() => {

--- a/src/components/sideMenu/container/sideMenuContainer.js
+++ b/src/components/sideMenu/container/sideMenuContainer.js
@@ -5,7 +5,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { logout, toggleAccountsBottomSheet } from '../../../redux/actions/uiAction';
 import { setInitPosts, setFeedPosts } from '../../../redux/actions/postsAction';
 
-
 // Component
 import SideMenuView from '../view/sideMenuView';
 

--- a/src/components/sideMenu/container/sideMenuContainer.js
+++ b/src/components/sideMenu/container/sideMenuContainer.js
@@ -33,6 +33,7 @@ const SideMenuContainer = ({ navigation }) => {
   };
 
   const _handlePressOptions = () => {
+    navigation.closeDrawer();
     dispatch(toggleAccountsBottomSheet(!isVisibleAccountsBottomSheet));
   };
 

--- a/src/components/sideMenu/container/sideMenuContainer.js
+++ b/src/components/sideMenu/container/sideMenuContainer.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 // Actions
-import { toggleAccountsBottomSheet } from '../../../redux/actions/uiAction';
+import { logout, toggleAccountsBottomSheet } from '../../../redux/actions/uiAction';
 import { setInitPosts, setFeedPosts } from '../../../redux/actions/postsAction';
-import { logout } from '../../../redux/actions/applicationActions';
+
 
 // Component
 import SideMenuView from '../view/sideMenuView';

--- a/src/components/sideMenu/view/sideMenuView.js
+++ b/src/components/sideMenu/view/sideMenuView.js
@@ -29,8 +29,7 @@ import { getVotingPower } from '../../../utils/manaBar';
 
 // Styles
 import styles from './sideMenuStyles';
-import { OptionsModal } from '../../atoms';
-import { toggleQRModal } from '../../../redux/actions/uiAction';
+import { showActionModal, toggleQRModal } from '../../../redux/actions/uiAction';
 
 // Images
 const SIDE_MENU_BACKGROUND = require('../../../assets/side_menu_background.png');
@@ -44,7 +43,6 @@ const SideMenuView = ({
 }) => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const ActionSheetRef = useRef(null);
 
   const [menuItems, setMenuItems] = useState(
     isLoggedIn ? MENU.AUTH_MENU_ITEMS : MENU.NO_AUTH_MENU_ITEMS,
@@ -74,7 +72,17 @@ const SideMenuView = ({
   // Component Functions
   const _handleOnMenuItemPress = (item) => {
     if (item.id === 'logout') {
-      ActionSheetRef.current.show();
+
+      dispatch(showActionModal({
+        title: intl.formatMessage({ id: 'side_menu.logout_text' }),
+        buttons: [{
+            text:intl.formatMessage({ id: 'side_menu.cancel' }),
+            onPress:()=>{}
+          },{
+            text:intl.formatMessage({ id: 'side_menu.logout' }),
+            onPress:()=>{ handleLogout() }
+          }]
+      }))
       return;
     }
 
@@ -198,19 +206,6 @@ const SideMenuView = ({
         <FlatList data={menuItems} keyExtractor={(item) => item.id} renderItem={_renderItem} />
       </View>
       <Text style={styles.versionText}>{`v${appVersion}, ${buildVersion}${storageT}`}</Text>
-      <OptionsModal
-        ref={ActionSheetRef}
-        options={[
-          intl.formatMessage({ id: 'side_menu.logout' }),
-          intl.formatMessage({ id: 'side_menu.cancel' }),
-        ]}
-        title={intl.formatMessage({ id: 'side_menu.logout_text' })}
-        cancelButtonIndex={1}
-        destructiveButtonIndex={0}
-        onPress={(index) => {
-          index === 0 ? handleLogout() : null;
-        }}
-      />
     </View>
   );
 };

--- a/src/components/sideMenu/view/sideMenuView.js
+++ b/src/components/sideMenu/view/sideMenuView.js
@@ -72,17 +72,23 @@ const SideMenuView = ({
   // Component Functions
   const _handleOnMenuItemPress = (item) => {
     if (item.id === 'logout') {
-
-      dispatch(showActionModal({
-        title: intl.formatMessage({ id: 'side_menu.logout_text' }),
-        buttons: [{
-            text:intl.formatMessage({ id: 'side_menu.cancel' }),
-            onPress:()=>{}
-          },{
-            text:intl.formatMessage({ id: 'side_menu.logout' }),
-            onPress:()=>{ handleLogout() }
-          }]
-      }))
+      dispatch(
+        showActionModal({
+          title: intl.formatMessage({ id: 'side_menu.logout_text' }),
+          buttons: [
+            {
+              text: intl.formatMessage({ id: 'side_menu.cancel' }),
+              onPress: () => {},
+            },
+            {
+              text: intl.formatMessage({ id: 'side_menu.logout' }),
+              onPress: () => {
+                handleLogout();
+              },
+            },
+          ],
+        }),
+      );
       return;
     }
 

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -547,8 +547,10 @@
     "wallet_updating":"Wallet update in progress, try again as update finishes",
     "claim_failed":"Failed to claim rewards, {message}\nTry again or write to support@ecency.com",
     "connection_issues":"The server is unreachable, please check your connection and try again.",
-    "open_settings":"Open Settings"
-  },
+    "open_settings":"Open Settings",
+    "auth_expired":"Authentication data expired.",
+    "logging_out":"Logging out {username}"
+    },
   "post": {
     "reblog_alert": "Are you sure you want to reblog?",
     "removed_hint": "Content is not available",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -548,7 +548,8 @@
     "claim_failed":"Failed to claim rewards, {message}\nTry again or write to support@ecency.com",
     "connection_issues":"The server is unreachable, please check your connection and try again.",
     "open_settings":"Open Settings",
-    "auth_expired":"Authentication data expired.",
+    "auth_expired":"We need to verify you still has access to your keys, please verify login.",
+    "verify":"Verify",
     "logging_out":"Logging out {username}"
     },
   "post": {

--- a/src/redux/actions/applicationActions.ts
+++ b/src/redux/actions/applicationActions.ts
@@ -16,8 +16,6 @@ import {
   IS_LOGIN_DONE,
   IS_NOTIFICATION_OPEN,
   LOGIN,
-  LOGOUT_DONE,
-  LOGOUT,
   SET_API,
   SET_CURRENCY,
   SET_LANGUAGE,
@@ -41,13 +39,7 @@ export const login = (payload) => ({
   type: LOGIN,
 });
 
-export const logout = () => ({
-  type: LOGOUT,
-});
 
-export const logoutDone = () => ({
-  type: LOGOUT_DONE,
-});
 
 export const isLoginDone = () => ({
   type: IS_LOGIN_DONE,

--- a/src/redux/actions/applicationActions.ts
+++ b/src/redux/actions/applicationActions.ts
@@ -39,8 +39,6 @@ export const login = (payload) => ({
   type: LOGIN,
 });
 
-
-
 export const isLoginDone = () => ({
   type: IS_LOGIN_DONE,
 });

--- a/src/redux/actions/uiAction.ts
+++ b/src/redux/actions/uiAction.ts
@@ -13,6 +13,8 @@ import {
   SHOW_REPLY_MODAL,
   HIDE_REPLY_MODAL,
   SET_LOCKED_ORIENTATION,
+  LOGOUT,
+  LOGOUT_DONE,
 } from '../constants/constants';
 
 export const updateActiveBottomTab = (payload: string) => ({
@@ -87,4 +89,12 @@ export const showReplyModal = (selectionPost: any) => ({
 
 export const hideReplyModal = () => ({
   type: HIDE_REPLY_MODAL,
+});
+
+export const logout = () => ({
+  type: LOGOUT,
+});
+
+export const logoutDone = () => ({
+  type: LOGOUT_DONE,
 });

--- a/src/redux/reducers/applicationReducer.ts
+++ b/src/redux/reducers/applicationReducer.ts
@@ -132,16 +132,7 @@ export default function (state = initialState, action): State {
         isConnected: action.payload,
       };
 
-    case LOGOUT:
-      return {
-        ...state,
-        isLogingOut: true,
-      };
-    case LOGOUT_DONE:
-      return {
-        ...state,
-        isLogingOut: false,
-      };
+
 
     case SET_API:
       return Object.assign({}, state, {

--- a/src/redux/reducers/applicationReducer.ts
+++ b/src/redux/reducers/applicationReducer.ts
@@ -132,8 +132,6 @@ export default function (state = initialState, action): State {
         isConnected: action.payload,
       };
 
-
-
     case SET_API:
       return Object.assign({}, state, {
         api: action.payload,

--- a/src/redux/reducers/uiReducer.ts
+++ b/src/redux/reducers/uiReducer.ts
@@ -13,6 +13,8 @@ import {
   SET_LOCKED_ORIENTATION,
   SHOW_REPLY_MODAL,
   HIDE_REPLY_MODAL,
+  LOGOUT,
+  LOGOUT_DONE,
 } from '../constants/constants';
 import { orientations } from '../constants/orientationsConstants';
 
@@ -30,6 +32,7 @@ interface UiState {
   lockedOrientation: string;
   replyModalVisible: boolean;
   replyModalPost: any;
+  isLogingOut: boolean;
 }
 
 const initialState: UiState = {
@@ -46,6 +49,7 @@ const initialState: UiState = {
   lockedOrientation: orientations.PORTRAIT,
   replyModalPost: null,
   replyModalVisible: false,
+  isLogingOut: false,
 };
 
 export default function (state = initialState, action): UiState {
@@ -134,6 +138,16 @@ export default function (state = initialState, action): UiState {
         ...state,
         replyModalVisible: false,
         replyModalPost: null,
+      };
+    case LOGOUT:
+      return {
+        ...state,
+        isLogingOut: true,
+      };
+    case LOGOUT_DONE:
+      return {
+        ...state,
+        isLogingOut: false,
       };
     default:
       return state;

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -682,7 +682,7 @@ class ApplicationContainer extends Component {
   
       if(!realmData[0]){
         //remove this user from data
-       throw new Error("user data invalid, logging out")
+       throw new Error("user data invalid")
       }
   
       // migreate account to use access token for master key auth type
@@ -709,6 +709,7 @@ class ApplicationContainer extends Component {
       dispatch(fetchSubscribedCommunities(_currentAccount.username));
 
     } catch(err){
+      dispatch(toastNotification("User's auth data expired, logging out..."))
       this._logout(targetAccount.username)
     }
 

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -594,6 +594,28 @@ class ApplicationContainer extends Component {
     };
   };
 
+  _promptAccountVerification = (username) => {
+    const {dispatch, intl} = this.props;
+        // keys data corrupted, ask user to verify login
+        dispatch(showActionModal({
+          title:intl.formatMessage({ id: 'alert.warning' }),
+          body:intl.formatMessage({ id: 'alert.auth_expired' }),
+          buttons:[{
+            text: intl.formatMessage({ id: 'alert.cancel' }), style: 'destructive' ,
+            onPress: ()=>{},
+         },
+         {
+            text: intl.formatMessage({ id: 'alert.verify' }), 
+            onPress: () => {
+              RootNavigation.navigate({
+                name: ROUTES.SCREENS.LOGIN,
+                params: { username:username },
+              });
+            },
+          },]
+        }))
+  }
+
   _logout = (username) => {
     const { otherAccounts, dispatch, intl } = this.props;
 
@@ -689,8 +711,8 @@ class ApplicationContainer extends Component {
       [_currentAccount.local] = realmData;
 
       if (!realmData[0]) {
-        // remove this user from data
-        throw new Error(intl.formatMessage({ id: 'alert.auth_expired' }));
+        this._promptAccountVerification(targetAccount.username)
+        return;
       }
 
       // migreate account to use access token for master key auth type

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -55,11 +55,9 @@ import {
 } from '../../../redux/actions/accountAction';
 import {
   login,
-  logoutDone,
   setConnectivityStatus,
   setPinCode as savePinCode,
   isRenderRequired,
-  logout,
   isPinCodeOpen,
   setEncryptedUnlockPin,
 } from '../../../redux/actions/applicationActions';
@@ -68,6 +66,8 @@ import {
   showActionModal,
   toastNotification,
   updateActiveBottomTab,
+  logout,
+  logoutDone
 } from '../../../redux/actions/uiAction';
 import { setFeedPosts, setInitPosts } from '../../../redux/actions/postsAction';
 import { fetchCoinQuotes } from '../../../redux/actions/walletActions';
@@ -584,6 +584,7 @@ class ApplicationContainer extends Component {
       intl,
     } = this.props;
 
+
     removeUserData(name)
       .then(async () => {
         const _otherAccounts = otherAccounts.filter((user) => user.username !== name);
@@ -771,7 +772,7 @@ export default connect(
     selectedLanguage: state.application.language,
     isPinCodeOpen: state.application.isPinCodeOpen,
     encUnlockPin: state.application.encUnlockPin,
-    isLogingOut: state.application.isLogingOut,
+
     isLoggedIn: state.application.isLoggedIn, // TODO: remove as is not being used in this class
     isConnected: state.application.isConnected,
     api: state.application.api,
@@ -790,7 +791,9 @@ export default connect(
     // UI
     toastNotification: state.ui.toastNotification,
     activeBottomTab: state.ui.activeBottomTab,
+    isLogingOut: state.ui.isLogingOut,
     rcOffer: state.ui.rcOffer,
+    
   }),
   (dispatch) => ({
     dispatch,

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -362,7 +362,7 @@ class ApplicationContainer extends Component {
   };
 
   _getUserDataFromRealm = async () => {
-    const { dispatch, isPinCodeOpen: _isPinCodeOpen, isConnected, otherAccounts, currentAccount } = this.props;
+    const { intl, dispatch, isPinCodeOpen: _isPinCodeOpen, isConnected, otherAccounts, currentAccount } = this.props;
     let realmData = [];
 
     const { username } = currentAccount;
@@ -406,9 +406,11 @@ class ApplicationContainer extends Component {
     if (realmData.length > 0) {
       const realmObject = realmData.filter((data) => data.username === username);
 
-      if (realmObject.length === 0) {
+      if (!realmObject[0]) {
         realmObject[0] = realmData[0];
         await switchAccount(realmObject[0].username);
+        dispatch(toastNotification(
+          `${intl.formatMessage({id:"alert.logging_out"},{username})}\n${intl.formatMessage({id:"alert.auth_expired"})}`))
       }
 
       // If in dev mode pin code does not show
@@ -666,7 +668,7 @@ class ApplicationContainer extends Component {
   };
 
   _switchAccount = async (targetAccount) => {
-    const { dispatch, isConnected, pinCode } = this.props;
+    const { dispatch, isConnected, pinCode, intl } = this.props;
 
     dispatch(updateCurrentAccount(targetAccount));
 
@@ -682,7 +684,7 @@ class ApplicationContainer extends Component {
   
       if(!realmData[0]){
         //remove this user from data
-       throw new Error("user data invalid")
+       throw new Error(intl.formatMessage({id:'alert.auth_expired'}))
       }
   
       // migreate account to use access token for master key auth type
@@ -709,7 +711,8 @@ class ApplicationContainer extends Component {
       dispatch(fetchSubscribedCommunities(_currentAccount.username));
 
     } catch(err){
-      dispatch(toastNotification("User's auth data expired, logging out..."))
+      dispatch(toastNotification(
+        `${intl.formatMessage({id:'alert.logging_out'},{username:targetAccount.username})}\n${err.message}`))
       this._logout(targetAccount.username)
     }
 

--- a/src/screens/login/container/loginContainer.tsx
+++ b/src/screens/login/container/loginContainer.tsx
@@ -272,10 +272,14 @@ class LoginContainer extends PureComponent {
   };
 
   render() {
-    const { navigation } = this.props;
+    const { navigation, route } = this.props;
     const { isLoading } = this.state;
+
+    const initialUsername = route.params?.username ?? ''
+
     return (
       <LoginScreen
+        initialUsername={initialUsername}
         navigation={navigation}
         handleOnPressLogin={this._handleOnPressLogin}
         getAccountsWithUsername={this._getAccountsWithUsername}

--- a/src/screens/login/screen/loginScreen.js
+++ b/src/screens/login/screen/loginScreen.js
@@ -34,12 +34,20 @@ class LoginScreen extends PureComponent {
     super(props);
 
     this.state = {
-      username: '',
+      username: props.initialUsername || '',
       password: '',
       isUsernameValid: true,
       keyboardIsOpen: false,
       isModalOpen: false,
     };
+
+    
+  }
+
+  componentDidMount(){
+    if(this.props.initialUsername){
+      this._handleUsernameChange(this.props.initialUsername)
+    }
   }
 
   componentWillUnmount() {

--- a/src/screens/pinCode/container/pinCodeContainer.tsx
+++ b/src/screens/pinCode/container/pinCodeContainer.tsx
@@ -14,8 +14,6 @@ import {
   isPinCodeOpen,
   isRenderRequired,
   login,
-  logout,
-  logoutDone,
   setEncryptedUnlockPin,
 } from '../../../redux/actions/applicationActions';
 import {
@@ -32,6 +30,7 @@ import MigrationHelpers from '../../../utils/migrationHelpers';
 
 // Component
 import PinCodeView from '../children/pinCodeView';
+import { logout, logoutDone } from '../../../redux/actions/uiAction';
 
 class PinCodeContainer extends Component {
   screenRef = null;

--- a/src/screens/settings/container/settingsContainer.tsx
+++ b/src/screens/settings/container/settingsContainer.tsx
@@ -41,7 +41,12 @@ import {
   setHidePostsThumbnails,
   setIsDarkTheme,
 } from '../../../redux/actions/applicationActions';
-import { logout, logoutDone, showActionModal, toastNotification } from '../../../redux/actions/uiAction';
+import {
+  logout,
+  logoutDone,
+  showActionModal,
+  toastNotification,
+} from '../../../redux/actions/uiAction';
 import { setPushToken, getNodes, deleteAccount } from '../../../providers/ecency/ecency';
 import { checkClient } from '../../../providers/hive/dhive';
 import { removeOtherAccount, updateCurrentAccount } from '../../../redux/actions/accountAction';

--- a/src/screens/settings/container/settingsContainer.tsx
+++ b/src/screens/settings/container/settingsContainer.tsx
@@ -35,15 +35,13 @@ import {
   setNsfw,
   isPinCodeOpen,
   login,
-  logoutDone,
   setColorTheme,
   setIsBiometricEnabled,
   setEncryptedUnlockPin,
   setHidePostsThumbnails,
-  logout,
   setIsDarkTheme,
 } from '../../../redux/actions/applicationActions';
-import { showActionModal, toastNotification } from '../../../redux/actions/uiAction';
+import { logout, logoutDone, showActionModal, toastNotification } from '../../../redux/actions/uiAction';
 import { setPushToken, getNodes, deleteAccount } from '../../../providers/ecency/ecency';
 import { checkClient } from '../../../providers/hive/dhive';
 import { removeOtherAccount, updateCurrentAccount } from '../../../redux/actions/accountAction';
@@ -81,12 +79,11 @@ class SettingsContainer extends Component {
 
   // Component Life Cycle Functions
   componentDidMount() {
-    getNodes()
-      .then((resp) => {
-        this.setState({
-          serverList: resp,
-        });
-      })
+    getNodes().then((resp) => {
+      this.setState({
+        serverList: resp,
+      });
+    });
   }
 
   // Component Functions


### PR DESCRIPTION
### What does this PR?
After testing a number of scenarios and trying to recreate the environment being faced by users, added a bunch snippets to help avoid embarrassing situations 

1 - purges malformed accounts
2 - logs out of app instead of logging into malformed account
3 - rearranged logout structure to avoid creating an undefined auth data state
4 - moved isLogingOut state to uiReducer so it gets reset on every app launch if routine is interupted for some reason

### Screenshots/Video
showing toast when auto detecting malformed user data detected on launch and when switching to logged in user after logging out
![Screenshot 2023-05-24 at 5 51 40 PM](https://github.com/ecency/ecency-mobile/assets/6298342/e2668788-1ef8-44d5-8e16-11e8b4709cfc)

showing logout prompt if invalid account detected regular account switch
![Screenshot 2023-05-24 at 5 54 35 PM](https://github.com/ecency/ecency-mobile/assets/6298342/87f3a4aa-8ab5-4bf9-a25f-3c0b278a1e00)

refine text button account switch sheet
![Screenshot 2023-05-24 at 6 07 23 PM](https://github.com/ecency/ecency-mobile/assets/6298342/d5063c0b-05d5-49bf-a45b-85b752af31bf)

using in app action modal instead of OptionsModal 
![Screenshot 2023-05-24 at 6 07 31 PM](https://github.com/ecency/ecency-mobile/assets/6298342/a45423c9-6e0d-475f-8366-a568ca9fe2d0)

