### PR TITLE
Nt/login repair patch

### DIFF
--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -95,7 +95,7 @@ const AccountsBottomSheetContainer = () => {
 
       _currentAccount.username = _currentAccount.name;
 
-      if (realmData[0]) {
+      if (!realmData[0]) {
         realmData = await repairUserAccountData(_currentAccount.username, dispatch, intl, accounts, pinHash);
         if(!realmData[0]){
           return;

--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -91,13 +91,15 @@ const AccountsBottomSheetContainer = () => {
 
       // fetch upto data account data nd update current account;
       let _currentAccount = await switchAccount(accountData.username);
-      const realmData = await getUserDataWithUsername(accountData.username);
+      let realmData = await getUserDataWithUsername(accountData.username);
 
       _currentAccount.username = _currentAccount.name;
 
-      if (!realmData[0]) {
-        repairUserAccountData(_currentAccount.username, dispatch, intl, accounts, pinHash);
-        return;
+      if (realmData[0]) {
+        realmData = await repairUserAccountData(_currentAccount.username, dispatch, intl, accounts, pinHash);
+        if(!realmData[0]){
+          return;
+        }
       }
 
       _currentAccount.local = realmData[0];

--- a/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
+++ b/src/components/accountsBottomSheet/container/accountsBottomSheetContainer.tsx
@@ -96,8 +96,14 @@ const AccountsBottomSheetContainer = () => {
       _currentAccount.username = _currentAccount.name;
 
       if (!realmData[0]) {
-        realmData = await repairUserAccountData(_currentAccount.username, dispatch, intl, accounts, pinHash);
-        if(!realmData[0]){
+        realmData = await repairUserAccountData(
+          _currentAccount.username,
+          dispatch,
+          intl,
+          accounts,
+          pinHash,
+        );
+        if (!realmData[0]) {
           return;
         }
       }

--- a/src/providers/hive/auth.js
+++ b/src/providers/hive/auth.js
@@ -30,16 +30,15 @@ export const login = async (username, password) => {
   let authType = '';
   // Get user account data from HIVE Blockchain
   const account = await getUser(username);
-  const isUserLoggedIn = await isLoggedInUser(username);
 
   if (!account) {
     return Promise.reject(new Error('auth.invalid_username'));
   }
 
-  if (isUserLoggedIn) {
-    //TODO: write routine to overwrite account data if already logged in
-    return Promise.reject(new Error('auth.already_logged'));
-  }
+  // if (isUserLoggedIn) {
+  //   //TODO: write routine to overwrite account data if already logged in
+  //   return Promise.reject(new Error('auth.already_logged'));
+  // }
 
   // Public keys of user
   const publicKeys = {
@@ -169,7 +168,7 @@ export const loginWithSC2 = async (code) => {
       memoKey: '',
       accessToken: '',
     };
-    const isUserLoggedIn = await isLoggedInUser(account.name);
+
 
     const resData = {
       pinCode: Config.DEFAULT_PIN,
@@ -180,10 +179,6 @@ export const loginWithSC2 = async (code) => {
     account.local = updatedUserData;
     account.local.avatar = avatar;
 
-    if (isUserLoggedIn) {
-      //TODO: write routine to overwrite account data if already logged in
-      throw new Error('auth.already_logged');
-    }
 
     await setUserData(account.local)
 
@@ -271,38 +266,6 @@ export const updatePinCode = (data) =>
     }
   });
 
-// export const verifyPinCode = async (data) => {
-//   try {
-//     const pinHash = await getPinCode();
-
-//     const result = await getUserDataWithUsername(data.username);
-//     const userData = result[0];
-
-//     // This is migration for new pin structure, it will remove v2.2
-//     if (!pinHash) {
-//       try {
-//         //if decrypt fails, means key is invalid
-//         if (userData.accessToken === AUTH_TYPE.STEEM_CONNECT) {
-//           decryptKey(userData.accessToken, data.pinCode);
-//         } else {
-//           decryptKey(userData.masterKey, data.pinCode);
-//         }
-//         await setPinCode(data.pinCode);
-//       } catch (error) {
-//         return Promise.reject(new Error('Invalid pin code, please check and try again'));
-//       }
-//     }
-
-//     if (sha256(get(data, 'pinCode')).toString() !== pinHash) {
-//       return Promise.reject(new Error('auth.invalid_pin'));
-//     }
-
-//     return true;
-//   } catch (err) {
-//     console.warn('Failed to verify pin in auth: ', data, err);
-//     return Promise.reject(err);
-//   }
-// };
 
 export const refreshSCToken = async (userData, pinCode) => {
   const scAccount = await getSCAccount(userData.username);
@@ -437,14 +400,6 @@ export const getUpdatedUserKeys = async (currentAccountData, data) => {
   return Promise.reject(new Error('auth.invalid_credentials'));
 };
 
-const isLoggedInUser = async (username) => {
-  const result = await getUserDataWithUsername(username);
-  const scAccount = await getSCAccount(username);
-  if (result.length > 0 && !!scAccount) {
-    return true;
-  }
-  return false;
-};
 
 /**
  * This migration snippet is used to update access token for users logged in using masterKey

--- a/src/providers/hive/auth.js
+++ b/src/providers/hive/auth.js
@@ -126,17 +126,15 @@ export const login = async (username, password) => {
 };
 
 export const loginWithSC2 = async (code) => {
-
   try {
     const scTokens = await getSCAccessToken(code);
     hsApi.setAccessToken(get(scTokens, 'access_token', ''));
     const scAccount = await hsApi.me();
-    
-    //NOTE: even though sAccount.account has account data but there are certain properties missing from hsApi variant, for instance account.username
-    //that is why we still have to fetch account data using dhive, thought post processing done in dhive variant can be done in utils in future
-    const account = await getUser(scAccount.account.name); 
+
+    // NOTE: even though sAccount.account has account data but there are certain properties missing from hsApi variant, for instance account.username
+    // that is why we still have to fetch account data using dhive, thought post processing done in dhive variant can be done in utils in future
+    const account = await getUser(scAccount.account.name);
     let avatar = '';
-    
 
     try {
       const accessToken = scTokens ? scTokens.access_token : '';
@@ -146,7 +144,6 @@ export const loginWithSC2 = async (code) => {
     } catch (err) {
       console.warn('Optional user data fetch failed, account can still function without them', err);
     }
-
 
     let jsonMetadata;
     try {
@@ -169,7 +166,6 @@ export const loginWithSC2 = async (code) => {
       accessToken: '',
     };
 
-
     const resData = {
       pinCode: Config.DEFAULT_PIN,
       accessToken: get(scTokens, 'access_token', ''),
@@ -179,8 +175,7 @@ export const loginWithSC2 = async (code) => {
     account.local = updatedUserData;
     account.local.avatar = avatar;
 
-
-    await setUserData(account.local)
+    await setUserData(account.local);
 
     await updateCurrentUsername(account.name);
     const authData = {
@@ -194,15 +189,11 @@ export const loginWithSC2 = async (code) => {
       ...account,
       accessToken: get(scTokens, 'access_token', ''),
     };
-
   } catch (err) {
-    bugsnapInstance.notify(err)
+    bugsnapInstance.notify(err);
     throw err;
   }
-
-
 };
-
 
 export const updatePinCode = (data) =>
   new Promise((resolve, reject) => {
@@ -265,7 +256,6 @@ export const updatePinCode = (data) =>
       reject(error.message);
     }
   });
-
 
 export const refreshSCToken = async (userData, pinCode) => {
   const scAccount = await getSCAccount(userData.username);
@@ -343,22 +333,22 @@ export const getUpdatedUserData = (userData, data) => {
         : '',
     postingKey:
       get(userData, 'authType', '') === AUTH_TYPE.MASTER_KEY ||
-        get(userData, 'authType', '') === AUTH_TYPE.POSTING_KEY
+      get(userData, 'authType', '') === AUTH_TYPE.POSTING_KEY
         ? encryptKey(get(privateKeys, 'postingKey', '').toString(), get(data, 'pinCode'))
         : '',
     activeKey:
       get(userData, 'authType', '') === AUTH_TYPE.MASTER_KEY ||
-        get(userData, 'authType', '') === AUTH_TYPE.ACTIVE_KEY
+      get(userData, 'authType', '') === AUTH_TYPE.ACTIVE_KEY
         ? encryptKey(get(privateKeys, 'activeKey', '').toString(), get(data, 'pinCode'))
         : '',
     memoKey:
       get(userData, 'authType', '') === AUTH_TYPE.MASTER_KEY ||
-        get(userData, 'authType', '') === AUTH_TYPE.MEMO_KEY
+      get(userData, 'authType', '') === AUTH_TYPE.MEMO_KEY
         ? encryptKey(get(privateKeys, 'memoKey', '').toString(), get(data, 'pinCode'))
         : '',
     ownerKey:
       get(userData, 'authType', '') === AUTH_TYPE.MASTER_KEY ||
-        get(userData, 'authType', '') === AUTH_TYPE.OWNER_KEY
+      get(userData, 'authType', '') === AUTH_TYPE.OWNER_KEY
         ? encryptKey(get(privateKeys, 'ownerKey', '').toString(), get(data, 'pinCode'))
         : '',
   };
@@ -399,7 +389,6 @@ export const getUpdatedUserKeys = async (currentAccountData, data) => {
   }
   return Promise.reject(new Error('auth.invalid_credentials'));
 };
-
 
 /**
  * This migration snippet is used to update access token for users logged in using masterKey

--- a/src/providers/hive/auth.js
+++ b/src/providers/hive/auth.js
@@ -37,6 +37,7 @@ export const login = async (username, password) => {
   }
 
   if (isUserLoggedIn) {
+    //TODO: write routine to overwrite account data if already logged in
     return Promise.reject(new Error('auth.already_logged'));
   }
 
@@ -180,6 +181,7 @@ export const loginWithSC2 = async (code) => {
     account.local.avatar = avatar;
 
     if (isUserLoggedIn) {
+      //TODO: write routine to overwrite account data if already logged in
       throw new Error('auth.already_logged');
     }
 

--- a/src/realm/realm.js
+++ b/src/realm/realm.js
@@ -57,9 +57,9 @@ export const setUserData = async (userData) => {
   try {
     const users = (await getItemFromStorage(USER_SCHEMA)) || [];
 
-    //replace user data if exist already else add new
-    const filteredUsers = users.filter((account) => account.username !== userData.username );
-    const _newData = [...filteredUsers, userData]
+    // replace user data if exist already else add new
+    const filteredUsers = users.filter((account) => account.username !== userData.username);
+    const _newData = [...filteredUsers, userData];
 
     await setItemToStorage(USER_SCHEMA, _newData);
 

--- a/src/realm/realm.js
+++ b/src/realm/realm.js
@@ -93,9 +93,9 @@ export const removeUserData = async (username) => {
     if (account.some((e) => e.username === username)) {
       account = account.filter((item) => item.username !== username);
       await setItemToStorage(USER_SCHEMA, account);
-      return true;
     }
-    return new Error('Could not remove selected user');
+
+    return true;
   } catch (error) {
     return error;
   }

--- a/src/redux/actions/accountAction.ts
+++ b/src/redux/actions/accountAction.ts
@@ -30,8 +30,8 @@ export const addOtherAccount = (data) => ({
 
 export const updateOtherAccount = (accountObj) => ({
   type: UPDATE_OTHER_ACCOUNT,
-  payload: accountObj
-})
+  payload: accountObj,
+});
 
 export const failedAccount = (data) => ({
   type: FETCH_ACCOUNT_FAIL,

--- a/src/redux/reducers/accountReducer.ts
+++ b/src/redux/reducers/accountReducer.ts
@@ -76,6 +76,7 @@ export default function (state = initialState, action) {
             [
               ...state.otherAccounts.filter((item) => item.username !== action.payload.username),
               action.payload,
+            ]
 
           : // add new account entry if it does not already exist
             [...state.otherAccounts, action.payload],

--- a/src/redux/reducers/accountReducer.ts
+++ b/src/redux/reducers/accountReducer.ts
@@ -72,7 +72,11 @@ export default function (state = initialState, action) {
         otherAccounts: state.otherAccounts.some(
           ({ username }) => username === get(action.payload, 'username'),
         )
-          ? [...state.otherAccounts]
+          //replace account data if it already exists
+          ? [...state.otherAccounts.filter(
+            (item) => item.username !== action.payload.username), action.payload]
+            
+          //add new account entry if it does not already exist
           : [...state.otherAccounts, action.payload],
         isFetching: false,
         hasError: false,

--- a/src/redux/reducers/accountReducer.ts
+++ b/src/redux/reducers/accountReducer.ts
@@ -77,7 +77,6 @@ export default function (state = initialState, action) {
               ...state.otherAccounts.filter((item) => item.username !== action.payload.username),
               action.payload,
             ]
-
           : // add new account entry if it does not already exist
             [...state.otherAccounts, action.payload],
         isFetching: false,

--- a/src/redux/reducers/accountReducer.ts
+++ b/src/redux/reducers/accountReducer.ts
@@ -72,27 +72,26 @@ export default function (state = initialState, action) {
         otherAccounts: state.otherAccounts.some(
           ({ username }) => username === get(action.payload, 'username'),
         )
-          //replace account data if it already exists
-          ? [...state.otherAccounts.filter(
-            (item) => item.username !== action.payload.username), action.payload]
-            
-          //add new account entry if it does not already exist
-          : [...state.otherAccounts, action.payload],
+          ? // replace account data if it already exists
+            [
+              ...state.otherAccounts.filter((item) => item.username !== action.payload.username),
+              action.payload,
+
+          : // add new account entry if it does not already exist
+            [...state.otherAccounts, action.payload],
         isFetching: false,
         hasError: false,
         errorMessage: null,
       };
 
-
     case UPDATE_OTHER_ACCOUNT:
       return {
         ...state,
         otherAccounts: [
-          ...state.otherAccounts.filter(
-            (item) => item.username !== action.payload.username),
-          action.payload
+          ...state.otherAccounts.filter((item) => item.username !== action.payload.username),
+          action.payload,
         ],
-      }
+      };
 
     case REMOVE_OTHER_ACCOUNT:
       return {

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -82,7 +82,10 @@ import parseVersionNumber from '../../../utils/parseVersionNumber';
 import { setMomentLocale } from '../../../utils/time';
 import { purgeExpiredCache } from '../../../redux/actions/cacheActions';
 import { fetchSubscribedCommunities } from '../../../redux/actions/communitiesAction';
-import MigrationHelpers, { repairOtherAccountsData, repairUserAccountData } from '../../../utils/migrationHelpers';
+import MigrationHelpers, {
+  repairOtherAccountsData,
+  repairUserAccountData,
+} from '../../../utils/migrationHelpers';
 import { deepLinkParser } from '../../../utils/deepLinkParser';
 import bugsnapInstance from '../../../config/bugsnag';
 import authType from '../../../constants/authType';
@@ -362,12 +365,10 @@ class ApplicationContainer extends Component {
 
   _refreshUnreadActivityCount = async () => {
     const { dispatch, isLoggedIn } = this.props;
-    if(isLoggedIn){
+    if (isLoggedIn) {
       const unreadActivityCount = await getUnreadNotificationCount();
       dispatch(updateUnreadActivityCount(unreadActivityCount));
     }
-
-   
   };
 
   _getUserDataFromRealm = async () => {
@@ -386,13 +387,11 @@ class ApplicationContainer extends Component {
 
       const username = currentAccount.name;
 
-
       const userData = await getUserData();
 
       if (userData && userData.length > 0) {
         realmData = userData;
         userData.forEach((accountData, index) => {
-   
           if (
             !accountData ||
             (!accountData.accessToken &&
@@ -410,15 +409,14 @@ class ApplicationContainer extends Component {
 
       const realmObject = realmData.filter((data) => data.username === username);
 
-
-      //reapir otherAccouts data is needed
-      //this repair must be done because code above makes sure every entry is realmData is a valid one
-      repairOtherAccountsData(otherAccounts, realmData, dispatch)
+      // reapir otherAccouts data is needed
+      // this repair must be done because code above makes sure every entry is realmData is a valid one
+      repairOtherAccountsData(otherAccounts, realmData, dispatch);
 
       if (!realmObject[0]) {
         // means current logged in user keys data not present, re-verify required
         this._repairUserAccountData(username);
-        //TODO: continue login routine after data repair is successful, return null if it fails
+        // TODO: continue login routine after data repair is successful, return null if it fails
         return null;
       }
 
@@ -578,7 +576,7 @@ class ApplicationContainer extends Component {
   _repairUserAccountData = async (username) => {
     const { dispatch, intl, otherAccounts, currentAccount, pinCode } = this.props;
 
-    //use current account variant if it exist of target account;
+    // use current account variant if it exist of target account;
     const _accounts = currentAccount.username === username ? [currentAccount] : otherAccounts;
     repairUserAccountData(username, dispatch, intl, _accounts, pinCode);
   };
@@ -587,9 +585,9 @@ class ApplicationContainer extends Component {
     const { otherAccounts, dispatch, intl } = this.props;
 
     try {
-      const response = await removeUserData(username)
+      const response = await removeUserData(username);
 
-      if(response instanceof Error){
+      if (response instanceof Error) {
         throw response;
       }
 
@@ -621,15 +619,11 @@ class ApplicationContainer extends Component {
       dispatch(setInitPosts([]));
       dispatch(removeOtherAccount(username));
       dispatch(logoutDone());
-
-    } 
-    
-    catch(err) {  
+    } catch (err) {
       dispatch(logoutDone());
       Alert.alert(intl.formatMessage({ id: 'alert.fail' }), err.message);
       this._repairUserAccountData(username);
     }
-    
   };
 
   _enableNotification = async (username, isEnable, settings = null, accessToken = null) => {
@@ -689,7 +683,7 @@ class ApplicationContainer extends Component {
 
       if (!realmData[0]) {
         this._repairUserAccountData(targetAccount.username);
-        //TODO: continue account data accumulation after repair
+        // TODO: continue account data accumulation after repair
         return;
       }
 

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -83,7 +83,6 @@ import MigrationHelpers, {
 import { deepLinkParser } from '../../../utils/deepLinkParser';
 import bugsnapInstance from '../../../config/bugsnag';
 
-
 let firebaseOnMessageListener: any = null;
 let appStateSub: NativeEventSubscription | null = null;
 let linkingEventSub: EventSubscription | null = null;
@@ -105,7 +104,6 @@ class ApplicationContainer extends Component {
     const { dispatch } = this.props;
 
     this._setNetworkListener();
-
 
     linkingEventSub = Linking.addEventListener('url', this._handleOpenURL);
     // TOOD: read initial URL
@@ -401,7 +399,7 @@ class ApplicationContainer extends Component {
         });
       }
 
-      let realmObject:any[] = realmData.filter((data) => data.username === username);
+      let realmObject: any[] = realmData.filter((data) => data.username === username);
 
       // reapir otherAccouts data is needed
       // this repair must be done because code above makes sure every entry is realmData is a valid one
@@ -410,9 +408,9 @@ class ApplicationContainer extends Component {
       if (!realmObject[0]) {
         // means current logged in user keys data not present, re-verify required
         realmObject = await this._repairUserAccountData(username);
-       
-        //disrupt routine if repair helper fails
-        if(!realmObject[0]){
+
+        // disrupt routine if repair helper fails
+        if (!realmObject[0]) {
           return null;
         }
       }
@@ -681,8 +679,8 @@ class ApplicationContainer extends Component {
       if (!realmData[0]) {
         realmData = await this._repairUserAccountData(targetAccount.username);
 
-        //disrupt routine if repair helper fails
-        if(!realmData[0]) {
+        // disrupt routine if repair helper fails
+        if (!realmData[0]) {
           return;
         }
       }

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -407,7 +407,7 @@ class ApplicationContainer extends Component {
       // this repair must be done because code above makes sure every entry is realmData is a valid one
       repairOtherAccountsData(otherAccounts, realmData, dispatch);
 
-      if (realmObject[0]) {
+      if (!realmObject[0]) {
         // means current logged in user keys data not present, re-verify required
         realmObject = await this._repairUserAccountData(username);
        

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -23,7 +23,6 @@ import ROUTES from '../../../constants/routeNames';
 
 // Services
 import {
-  getAuthStatus,
   getUserData,
   removeUserData,
   getUserDataWithUsername,
@@ -33,13 +32,10 @@ import {
   setExistUser,
   getLastUpdateCheck,
   setLastUpdateCheck,
-  getSCAccount,
 } from '../../../realm/realm';
 import { getUser, getDigitPinCode, getMutes } from '../../../providers/hive/dhive';
 import { getPointsSummary } from '../../../providers/ecency/ePoint';
 import {
-  login as loginWithKey,
-  loginWithSC2,
   migrateToMasterKeyWithAccessToken,
   refreshSCToken,
   switchAccount,
@@ -50,7 +46,6 @@ import RootNavigation from '../../../navigation/rootNavigation';
 
 // Actions
 import {
-  addOtherAccount,
   updateCurrentAccount,
   updateUnreadActivityCount,
   removeOtherAccount,
@@ -77,7 +72,6 @@ import { fetchCoinQuotes } from '../../../redux/actions/walletActions';
 
 import { decryptKey, encryptKey } from '../../../utils/crypto';
 
-import persistAccountGenerator from '../../../utils/persistAccountGenerator';
 import parseVersionNumber from '../../../utils/parseVersionNumber';
 import { setMomentLocale } from '../../../utils/time';
 import { purgeExpiredCache } from '../../../redux/actions/cacheActions';
@@ -88,8 +82,7 @@ import MigrationHelpers, {
 } from '../../../utils/migrationHelpers';
 import { deepLinkParser } from '../../../utils/deepLinkParser';
 import bugsnapInstance from '../../../config/bugsnag';
-import authType from '../../../constants/authType';
-import { delay } from '../../../utils/editor';
+
 
 let firebaseOnMessageListener: any = null;
 let appStateSub: NativeEventSubscription | null = null;

--- a/src/screens/application/container/applicationContainer.tsx
+++ b/src/screens/application/container/applicationContainer.tsx
@@ -418,6 +418,7 @@ class ApplicationContainer extends Component {
       if (!realmObject[0]) {
         // means current logged in user keys data not present, re-verify required
         this._repairUserAccountData(username);
+        //TODO: continue login routine after data repair is successful, return null if it fails
         return null;
       }
 
@@ -688,6 +689,7 @@ class ApplicationContainer extends Component {
 
       if (!realmData[0]) {
         this._repairUserAccountData(targetAccount.username);
+        //TODO: continue account data accumulation after repair
         return;
       }
 

--- a/src/screens/login/container/loginContainer.tsx
+++ b/src/screens/login/container/loginContainer.tsx
@@ -148,8 +148,9 @@ class LoginContainer extends PureComponent {
       .catch((error) => {
         this.setState({ isLoading: false });
         Alert.alert(
-          intl.formatMessage({ id: 'alert.fail' }), 
-          intl.formatMessage({ id: error.message }));
+          intl.formatMessage({ id: 'alert.fail' }),
+          intl.formatMessage({ id: error.message }),
+        );
       });
   };
 
@@ -196,8 +197,8 @@ class LoginContainer extends PureComponent {
         const errorDescription = err?.response?.data?.error_description
           ? err?.response?.data?.error_description
           : intl.formatMessage({
-            id: err.message,
-          });
+              id: err.message,
+            });
         Alert.alert(
           intl.formatMessage({
             id: 'login.login_failed',

--- a/src/screens/register/registerScreen.tsx
+++ b/src/screens/register/registerScreen.tsx
@@ -230,7 +230,7 @@ const RegisterScreen = ({ navigation, route }) => {
             rightInfoIcon
             errorInfo={usernameError}
             type="username"
-            isFirstImage={isUserExist ? true : false}
+            isFirstImage={!!isUserExist}
             value={username}
             inputStyle={styles.input}
             onFocus={() => setKeyboardIsOpen(true)}

--- a/src/screens/steem-connect/hiveSigner.js
+++ b/src/screens/steem-connect/hiveSigner.js
@@ -65,18 +65,16 @@ class HiveSigner extends PureComponent {
                 });
               }
             } else {
-              throw new Error('alert.unknow_error')
+              throw new Error('alert.unknow_error');
             }
           })
           .catch((error) => {
             Alert.alert(
               intl.formatMessage({ id: 'alert.fail' }),
               intl.formatMessage({
-                id:
-                  error.message,
+                id: error.message,
               }),
             );
-
           });
       }
     }
@@ -88,10 +86,11 @@ class HiveSigner extends PureComponent {
         <StatusBar hidden translucent />
         <WebView
           source={{
-            uri: `${hsOptions.base_url}oauth2/authorize?client_id=${hsOptions.client_id
-              }&redirect_uri=${encodeURIComponent(
-                hsOptions.redirect_uri,
-              )}&response_type=code&scope=${encodeURIComponent(hsOptions.scope)}`,
+            uri: `${hsOptions.base_url}oauth2/authorize?client_id=${
+              hsOptions.client_id
+            }&redirect_uri=${encodeURIComponent(
+              hsOptions.redirect_uri,
+            )}&response_type=code&scope=${encodeURIComponent(hsOptions.scope)}`,
           }}
           onNavigationStateChange={this._onNavigationStateChange}
           ref={(ref) => {

--- a/src/utils/migrationHelpers.ts
+++ b/src/utils/migrationHelpers.ts
@@ -169,7 +169,7 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
 };
 
 export const repairUserAccountData = async (username, dispatch, intl, accounts, pinHash) => {
-  let authData:any[] = [];
+  let authData: any[] = [];
   try {
     // clean realm data just in case, to avoid already logged error
     await removeUserData(username);
@@ -200,9 +200,8 @@ export const repairUserAccountData = async (username, dispatch, intl, accounts, 
 
     dispatch(updateCurrentAccount({ ..._userAccount }));
 
-    //compile authData for return;
+    // compile authData for return;
     authData = [_userAccount.local];
-
   } catch (err) {
     // keys data corrupted, ask user to verify login
     await delay(500);
@@ -230,7 +229,7 @@ export const repairUserAccountData = async (username, dispatch, intl, accounts, 
     );
   }
 
-  return authData
+  return authData;
 };
 
 export const repairOtherAccountsData = (accounts, realmAuthData, dispatch) => {

--- a/src/utils/migrationHelpers.ts
+++ b/src/utils/migrationHelpers.ts
@@ -170,8 +170,6 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
 
 export const repairUserAccountData = async (username, dispatch, intl, accounts, pinHash) => {
   try {
-
-    
     // clean realm data just in case, to avoid already logged error
     await removeUserData(username);
 
@@ -228,18 +226,16 @@ export const repairUserAccountData = async (username, dispatch, intl, accounts, 
   }
 };
 
-
-export const repairOtherAccountsData = (accounts, realmAuthData, dispatch, ) => {
+export const repairOtherAccountsData = (accounts, realmAuthData, dispatch) => {
   accounts.forEach((account) => {
-    const accRealmData = realmAuthData.find(data => data.username === account.name)
-    if((!account.local?.accessToken || !account.username) && accRealmData){
+    const accRealmData = realmAuthData.find((data) => data.username === account.name);
+    if ((!account.local?.accessToken || !account.username) && accRealmData) {
       account.local = accRealmData;
       account.username = accRealmData.username;
-      dispatch(updateOtherAccount({...account}));
+      dispatch(updateOtherAccount({ ...account }));
     }
-  })
-}
-
+  });
+};
 
 const reduxMigrations = {
   0: (state) => {

--- a/src/utils/migrationHelpers.ts
+++ b/src/utils/migrationHelpers.ts
@@ -170,6 +170,11 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
 
 export const repairUserAccountData = async (username, dispatch, intl, accounts, pinHash) => {
   try {
+
+    
+    // clean realm data just in case, to avoid already logged error
+    await removeUserData(username);
+
     // extract key information from otherAccounts if data is available, use key to re-verify account;
     let _userAccount = accounts.find((account) => account.username === username);
     const _authType = _userAccount?.local?.authType;
@@ -177,8 +182,6 @@ export const repairUserAccountData = async (username, dispatch, intl, accounts, 
       throw new Error('could not recover account data from redux copy');
     }
 
-    // clean realm data just in case, to avoid already logged error
-    await removeUserData(username);
     if (_authType === AUTH_TYPE.STEEM_CONNECT) {
       const _scAccount = await getSCAccount(username);
       if (!_scAccount?.refreshToken) {

--- a/src/utils/migrationHelpers.ts
+++ b/src/utils/migrationHelpers.ts
@@ -169,6 +169,7 @@ export const migrateUserEncryption = async (dispatch, currentAccount, encUserPin
 };
 
 export const repairUserAccountData = async (username, dispatch, intl, accounts, pinHash) => {
+  let authData:any[] = [];
   try {
     // clean realm data just in case, to avoid already logged error
     await removeUserData(username);
@@ -198,6 +199,10 @@ export const repairUserAccountData = async (username, dispatch, intl, accounts, 
     }
 
     dispatch(updateCurrentAccount({ ..._userAccount }));
+
+    //compile authData for return;
+    authData = [_userAccount.local];
+
   } catch (err) {
     // keys data corrupted, ask user to verify login
     await delay(500);
@@ -224,6 +229,8 @@ export const repairUserAccountData = async (username, dispatch, intl, accounts, 
       }),
     );
   }
+
+  return authData
 };
 
 export const repairOtherAccountsData = (accounts, realmAuthData, dispatch) => {


### PR DESCRIPTION
### What does this PR?
- Updates auth data even if user is already logged in, it would get user out of login roadblock, also allows user to change key type if needed
- rearranged account repair code to avoid early verify prompt
- on successful account repair, continue login routine instead of disrupting it
- during logout, if authData is not present, avoid throwing error, condition is acceptable
