### PR TITLE
[Bug Fix] fixed comment copy link bug

### DIFF
--- a/src/components/quickReplyModal/quickReplyModalContent.tsx
+++ b/src/components/quickReplyModal/quickReplyModalContent.tsx
@@ -140,10 +140,13 @@ export const QuickReplyModalContent = forwardRef(
         setIsSending(true);
 
         const permlink = generateReplyPermlink(selectedPost.author);
-
+        const author = currentAccount.name;
         const parentAuthor = selectedPost.author;
         const parentPermlink = selectedPost.permlink;
         const parentTags = selectedPost.json_metadata.tags;
+        const category = get(selectedPost, 'category', '');
+        const url = `/${category}/@${parentAuthor}/${parentPermlink}#@${author}/${permlink}`;
+
         console.log(
           currentAccount,
           pinCode,
@@ -186,13 +189,14 @@ export const QuickReplyModalContent = forwardRef(
             );
 
             // add comment cache entry
-            const author = currentAccount.name;
+
             dispatch(
               updateCommentCache(
                 `${author}/${permlink}`,
                 {
                   author,
                   permlink,
+                  url,
                   parent_author: parentAuthor,
                   parent_permlink: parentPermlink,
                   markdownBody: commentValue,

--- a/src/redux/reducers/cacheReducer.ts
+++ b/src/redux/reducers/cacheReducer.ts
@@ -54,6 +54,7 @@ export interface Comment {
   expandedReplies?: boolean;
   renderOnTop?: boolean;
   status: CacheStatus;
+  url?: string;
 }
 
 export interface Draft {


### PR DESCRIPTION
### What does this PR?
This PR fixes a bug while copying link of newly created comment on a post. This was happening due to missing url in comment cache

### Issue number
fixes #2734 

### Screenshots/Video

https://github.com/ecency/ecency-mobile/assets/48380998/a8a5bd4d-0aca-47a2-a757-0026c157640c

