### PR TITLE
Nt/wave image ratios

### DIFF
--- a/src/components/comment/view/commentView.tsx
+++ b/src/components/comment/view/commentView.tsx
@@ -104,6 +104,7 @@ const CommentView = ({
       <View style={[{ marginLeft: 2, marginTop: -6 }]}>
         <CommentBody
           body={comment.body}
+          metadata={comment.json_metadata}
           key={`key-${comment.permlink}`}
           hideContent={_hideContent}
           commentDepth={_depth}

--- a/src/components/postElements/body/view/commentBodyView.tsx
+++ b/src/components/postElements/body/view/commentBodyView.tsx
@@ -24,6 +24,7 @@ const WIDTH = getWindowDimensions().width;
 
 interface CommentBodyProps {
   body: string;
+  metadata?: any;
   commentDepth: number;
   hideContent: boolean;
   handleOnContentPress: () => void;
@@ -38,6 +39,7 @@ interface CommentBodyProps {
 
 const CommentBody = ({
   body,
+  metadata,
   commentDepth,
   hideContent,
   handleOnContentPress,
@@ -132,6 +134,7 @@ const CommentBody = ({
             <PostHtmlRenderer
               contentWidth={_contentWidth}
               body={body}
+              metadata={metadata}
               isComment={true}
               setSelectedImage={handleImagePress}
               setSelectedLink={handleLinkPress}

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -13,7 +13,7 @@ import { VideoPlayer } from '..';
 interface PostHtmlRendererProps {
   contentWidth: number;
   body: string;
-  metadata: string;
+  metadata: any;
   isComment?: boolean;
   onLoaded?: () => void;
   setSelectedImage: (imgUrl: string, postImageUrls: string[]) => void;

--- a/src/components/quickReplyModal/usePostSubmitter.ts
+++ b/src/components/quickReplyModal/usePostSubmitter.ts
@@ -1,7 +1,7 @@
 import { useDispatch } from "react-redux";
 import { useAppSelector } from "../../hooks";
 import { postComment } from "../../providers/hive/dhive";
-import { generateReplyPermlink, makeJsonMetadataReply } from "../../utils/editor";
+import { extractMetadata, generateReplyPermlink, makeJsonMetadata } from "../../utils/editor";
 import { Alert } from "react-native";
 import { updateCommentCache } from "../../redux/actions/cacheActions";
 import { toastNotification } from "../../redux/actions/uiAction";
@@ -46,6 +46,13 @@ export const usePostSubmitter = () => {
             const category = parentPost.category || '';
             const url = `/${category}/@${parentAuthor}/${parentPermlink}#@${author}/${permlink}`;
 
+            //adding jsonmeta with image ratios here....
+            const meta = await extractMetadata({
+                body:commentBody,
+                fetchRatios:true
+            })
+            const jsonMetadata = makeJsonMetadata(meta, parentTags || ['ecency'])
+
             console.log(
                 currentAccount,
                 pinCode,
@@ -53,7 +60,7 @@ export const usePostSubmitter = () => {
                 parentPermlink,
                 permlink,
                 commentBody,
-                parentTags,
+                jsonMetadata
             );
 
 
@@ -65,7 +72,8 @@ export const usePostSubmitter = () => {
                     parentPermlink,
                     permlink,
                     commentBody,
-                    parentTags,
+                    [],
+                    jsonMetadata
                 )
 
                 userActivityMutation.mutate({
@@ -90,7 +98,7 @@ export const usePostSubmitter = () => {
                     parent_author: parentAuthor,
                     parent_permlink: parentPermlink,
                     markdownBody: commentBody,
-                    json_metadata: makeJsonMetadataReply(parentTags || ['ecency'])
+                    json_metadata: jsonMetadata
                 }
                 
                 dispatch(

--- a/src/providers/hive/dhive.js
+++ b/src/providers/hive/dhive.js
@@ -1510,7 +1510,7 @@ export const postComment = (
   permlink,
   body,
   parentTags,
-  isEdit = false,
+  jsonMetadata = null,
 ) =>
   _postContent(
     account,
@@ -1520,7 +1520,7 @@ export const postComment = (
     permlink,
     '',
     body,
-    makeJsonMetadataReply(parentTags || ['ecency']),
+    jsonMetadata ? jsonMetadata : makeJsonMetadataReply(parentTags || ['ecency']),
     null,
     null,
   )

--- a/src/redux/actions/cacheActions.ts
+++ b/src/redux/actions/cacheActions.ts
@@ -18,7 +18,6 @@ import {
   DELETE_CLAIM_CACHE_ENTRY,
 } from '../constants/constants';
 import {
-  ClaimCache,
   Comment,
   CacheStatus,
   Draft,


### PR DESCRIPTION
### What does this PR?
waves image_ratio support in json_metadata, will be great to have this data injected from web created waves as well to make overall waves exploring smooth.

![Screenshot 2023-09-21 at 4 04 09 PM](https://github.com/ecency/ecency-mobile/assets/6298342/3c4d4b5e-a75f-4500-a68e-d8597dd951b9)

### Issue number
https://github.com/orgs/ecency/projects/2#card-90366283

### Screenshots/Video
In demo video the first wave image appeared with default size even while the image itself was cached, such images were causing glitch while rendering... 
In comparison, the `DEV TEST!` (3rd post in video) from demo.com appeared wellformed without borders
https://github.com/ecency/ecency-mobile/assets/6298342/ec180291-8b32-48e4-ba4d-3c54d9e5c697


