### PR TITLE
separated ImageNotifi, no longer need updating build settings

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -76,7 +76,7 @@ target 'Ecency' do
 
       target.build_configurations.each do |config|
         config.build_settings["ONLY_ACTIVE_ARCH"] = "NO"
-        config.build_settings['APPLICATION_EXTENSION_API_ONLY'] = 'No'
+      
       end
 
       #this workaround resolves duplicate symbolds caused by GCDAsyncSocket inclusion in TcpSockets
@@ -98,6 +98,8 @@ target 'Ecency' do
   end
 
 end
+
+
 target 'ImageNotifi' do
-  pod 'Firebase/Messaging', '~> 8.15.0' # eg 8.15.0
+  pod 'Firebase/Messaging'
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -679,7 +679,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
-  - Firebase/Messaging (~> 8.15.0)
+  - Firebase/Messaging
   - Flipper (= 0.164.0)
   - Flipper-Boost-iOSX (= 1.76.0.1.11)
   - Flipper-DoubleConversion (= 3.2.0.1)
@@ -1110,6 +1110,6 @@ SPEC CHECKSUMS:
   Yoga: 92d086bb705a41cc588599b51db726ba7b1d341c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: db95fd9e03b853e1c341543b7a25465965e748b6
+PODFILE CHECKSUM: 6b212d63236c21489948e9b73b59fcff2feeeb08
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
### What does this PR?
- removing version auto adapting to primary target version of messaging
- no longer needing build setting updates
- building successfully

