### PR TITLE
injecting image urls and ratios in comment metadata

### DIFF
--- a/src/components/quickReplyModal/usePostSubmitter.ts
+++ b/src/components/quickReplyModal/usePostSubmitter.ts
@@ -78,7 +78,6 @@ export const usePostSubmitter = () => {
                     parentPermlink,
                     permlink,
                     commentBody,
-                    [],
                     jsonMetadata
                 )
 

--- a/src/providers/hive/dhive.js
+++ b/src/providers/hive/dhive.js
@@ -1509,8 +1509,7 @@ export const postComment = (
   parentPermlink,
   permlink,
   body,
-  parentTags,
-  jsonMetadata = null,
+  jsonMetadata,
 ) =>
   _postContent(
     account,
@@ -1520,7 +1519,7 @@ export const postComment = (
     permlink,
     '',
     body,
-    jsonMetadata ? jsonMetadata : makeJsonMetadataReply(parentTags || ['ecency']),
+    jsonMetadata,
     null,
     null,
   )

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -49,6 +49,7 @@ import bugsnapInstance from '../../../config/bugsnag';
 import { useUserActivityMutation } from '../../../providers/queries/pointQueries';
 import { PointActivityIds } from '../../../providers/ecency/ecency.types';
 import { usePostsCachePrimer } from '../../../providers/queries/postQueries/postQueries';
+import { PostTypes } from '../../../constants/postTypes';
 
 /*
  *            Props Name        Description                                     Value
@@ -716,6 +717,13 @@ class EditorContainer extends Component<EditorContainerProps, any> {
       const parentTags = post.json_metadata.tags;
       const draftId = `${currentAccount.name}/${parentAuthor}/${parentPermlink}`; // different draftId for each user acount
 
+      const meta = await extractMetadata({
+        body: fields.body,
+        fetchRatios: true,
+        postType: PostTypes.COMMENT
+      })
+      const jsonMetadata = makeJsonMetadata(meta, parentTags || ['ecency'])
+
       await postComment(
         currentAccount,
         pinCode,
@@ -723,7 +731,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         parentPermlink,
         permlink,
         fields.body,
-        parentTags,
+        jsonMetadata
       )
         .then((response) => {
           // record user activity for points
@@ -1135,7 +1143,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         handleShouldReblogChange={this._handleShouldReblogChange}
         handleSchedulePress={this._handleSchedulePress}
         handleFormChanged={this._handleFormChanged}
-        handleOnBackPress={() => {}}
+        handleOnBackPress={() => { }}
         handleOnSubmit={this._handleSubmit}
         initialEditor={this._initialEditor}
         isDarkTheme={isDarkTheme}


### PR DESCRIPTION
### What does this PR?
Injecting image url was already supported for comment using quick reply modal, now added similar support for main editor comments as well

### Screenshots/Video

Main editor comment metadata
![Screenshot 2023-10-17 at 5 25 50 PM](https://github.com/ecency/ecency-mobile/assets/6298342/169454c3-df75-49a4-b2ea-a850afb43722)

Quick reply modal metadata
![Screenshot 2023-10-17 at 5 20 04 PM](https://github.com/ecency/ecency-mobile/assets/6298342/3a2ca568-ab45-4dc8-9ac6-c52cf5c2511e)

data retention on update
![Screenshot 2023-10-17 at 5 26 24 PM](https://github.com/ecency/ecency-mobile/assets/6298342/1df55595-833c-4ebe-a8d2-1bbd3dba52ad)
