### PR TITLE
[Bug Fix] post screen with video crashes upon scrolling to end

### DIFF
--- a/src/components/postComments/container/postComments.tsx
+++ b/src/components/postComments/container/postComments.tsx
@@ -331,6 +331,7 @@ const PostComments = forwardRef(
               colors={['#fff']}
             />
           }
+          overScrollMode="never"
         />
         <PostHtmlInteractionHandler 
           ref={postInteractionRef}


### PR DESCRIPTION
### What does this PR?
This PR fixes the crash issue in post screen having a video upon scrolling to end.
Mainly this is due to overScrollMode prop in flatlist/flashlist

### Issue number
https://discord.com/channels/@me/920267778190086205/1164118841153036368

### Screenshots/Video

https://github.com/ecency/ecency-mobile/assets/48380998/79bb5a44-aef7-4ba3-8a31-29d9795d2b63

