### PR TITLE
[Bug Fix] mute unmute not updating in profile screen

### DIFF
--- a/src/containers/profileContainer.js
+++ b/src/containers/profileContainer.js
@@ -52,7 +52,7 @@ class ProfileContainer extends Component {
       user: null,
       quickProfile: {
         reputation: get(props, 'route.params.reputation', ''),
-        name: isOwnProfile ? currentAccountUsername : username
+        name: isOwnProfile ? currentAccountUsername : username,
       },
       reverseHeader: true,
       deepLinkFilter: get(props, 'route.params.deepLinkFilter'),
@@ -166,6 +166,9 @@ class ProfileContainer extends Component {
             mutes.splice(mutedIndex, 1);
             currentAccount.mutes = mutes;
             dispatch(updateCurrentAccount(currentAccount));
+            this.setState({
+              isMuted: false,
+            });
           }
         }
 
@@ -483,7 +486,6 @@ class ProfileContainer extends Component {
       navigation.navigate(ROUTES.SCREENS.LOGIN);
       return;
     }
-
   }
 
   render() {


### PR DESCRIPTION
### What does this PR?
This PR fixes a bug in profile screen when user is muted/unmuted the state was not updating properly

### Steps to reproduce
Go to Profile Screen and mute the user. Then unmute the user. Mute/Unmute functions works properly now
### Issue number
fixes #2786 

### Screenshots/Video

https://github.com/ecency/ecency-mobile/assets/48380998/7e909325-a98c-4420-ab83-3f7ec0272d73

