### PR TITLE
[Bug Fix] Infinite pull to refresh loader

### DIFF
--- a/src/components/postComments/container/postComments.tsx
+++ b/src/components/postComments/container/postComments.tsx
@@ -50,6 +50,8 @@ const PostComments = forwardRef(
       handleOnCommentsLoaded,
       handleOnReplyPress,
       onUpvotePress,
+      refreshing,
+      setRefreshing,
     },
     ref,
   ) => {
@@ -71,8 +73,6 @@ const PostComments = forwardRef(
     const [selectedFilter, setSelectedFilter] = useState('trending');
     const [selectedOptionIndex, setSelectedOptionIndex] = useState(0);
     const [headerHeight, setHeaderHeight] = useState(0);
-
-    const [refreshing, setRefreshing] = useState(false);
 
     const sortedSections = useMemo(
       () => sortComments(selectedFilter, discussionQuery.sectionedData),

--- a/src/components/postView/view/postDisplayView.tsx
+++ b/src/components/postView/view/postDisplayView.tsx
@@ -324,6 +324,8 @@ const PostDisplayView = ({
           isPostLoading={postBodyLoading}
           postContentView={_postContentView}
           onRefresh={onRefresh}
+          refreshing={refreshing}
+          setRefreshing={setRefreshing}
           onUpvotePress={_onUpvotePress}
         />
       </View>


### PR DESCRIPTION
### What does this PR?
This PR fixes the bug in post screen which was causing infinite refresh indicator loader when post is pulled down to refresh


### Steps to reproduce
Go to post screen for viewing post and pull down to refresh the post. The infinite loader is fixed now

### Issue number
https://discord.com/channels/@me/920267778190086205/1185948771985674280

### Screenshots/Video

https://github.com/ecency/ecency-mobile/assets/48380998/2f240f3a-d382-4293-87cc-4d05ac577ba9

