### PR TITLE
[Bug Fix] Post crashed due to old image aspect ratio meta data

### DIFF
--- a/src/components/tabbedPosts/view/tabContent.tsx
+++ b/src/components/tabbedPosts/view/tabContent.tsx
@@ -290,7 +290,7 @@ const TabContent = ({
   };
 
   const _scrollToTop = () => {
-    postsListRef.current.scrollToTop();
+    postsListRef?.current?.scrollToTop();
     setEnableScrollTop(false);
     scrollPopupDebouce.cancel();
     blockPopup = true;

--- a/src/providers/queries/postQueries/postQueries.ts
+++ b/src/providers/queries/postQueries/postQueries.ts
@@ -203,7 +203,7 @@ export const useInjectVotesCache = (_data: any | any[]) => {
   const [retData, setRetData] = useState<any | any[] | null>(null);
 
   useEffect(() => {
-    if (retData && lastUpdate.type === 'vote') {
+    if (retData && lastUpdate && lastUpdate.type === 'vote') {
       const _postPath = lastUpdate.postPath;
       const _voteCache = votesCollection[_postPath];
 

--- a/src/utils/postParser.tsx
+++ b/src/utils/postParser.tsx
@@ -54,8 +54,15 @@ export const parsePost = (
 
   // find and inject thumbnail ratio
   if (post.json_metadata.image_ratios) {
-    if (!Number.isNaN(post.json_metadata.image_ratios[0])) {
+    const imgRatios = post.json_metadata.image_ratios;
+    if (typeof imgRatios[0] === 'number' && !Number.isNaN(imgRatios[0])) {
       [post.thumbRatio] = post.json_metadata.image_ratios;
+    } else if (imgRatios.length && imgRatios[0].height && imgRatios[0].width) {
+      // convert to image ratio if old meta data found
+      post.json_metadata.image_ratios = imgRatios.map((item) => {
+        const ratio = item.width / item.height;
+        return item.width && item.height ? parseFloat(ratio.toFixed(4)) : item;
+      });
     }
   }
 


### PR DESCRIPTION
### What does this PR?
This PR fixes the issue causing crash in post screen for post having old meta data of image ratio.
The issue exists for app version 3.0.31 

### Steps to reproduce
Go to [this post](https://ecency.com/hive-125125/@good-karma/letter-to-our-community) on ecency mobile 
App gets crashed

### Issue number
https://discord.com/channels/@me/920267778190086205/1194632884649197628

### Screenshots/Video

https://github.com/ecency/ecency-mobile/assets/48380998/a4a4558f-206e-499b-b86a-688070e2650c

