### PR TITLE
fixed default from value extractor issue, disabled lint checker

### DIFF
--- a/src/utils/hive-uri.ts
+++ b/src/utils/hive-uri.ts
@@ -19,7 +19,8 @@ const _checkOpsArray = (ops: any) => {
 };
 
 const findParentKey = (obj, value, parentKey = null) => {
-  Object.keys(obj).forEach((key) => {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const key in obj) {
     if (obj[key] === value) {
       return parentKey;
     } else if (typeof obj[key] === 'object') {
@@ -28,7 +29,7 @@ const findParentKey = (obj, value, parentKey = null) => {
         return foundKey;
       }
     }
-  });
+  }
   return null;
 };
 


### PR DESCRIPTION
### What does this PR?
the method used for extracting signer filed information apparently started malfunctioning after we did app wide lint fixes. disabled lint for the for loop in method.

There is a way to achieve same result without for loop, but for now it seemed like a simple quick fix

### Issue number
https://discord.com/channels/@me/920267778190086205/1198492766406184971

### Screenshots/Video
<img width="378" alt="Screenshot_2024-01-21_at_10 32 30" src="https://github.com/ecency/ecency-mobile/assets/6298342/8b2f2b4d-e543-426c-9ba4-92c3ceb02aca">
