### PR TITLE
temporarily remove save image option

### DIFF
--- a/src/components/postElements/body/view/postBodyView.js
+++ b/src/components/postElements/body/view/postBodyView.js
@@ -89,10 +89,10 @@ const PostBody = ({ body, metadata, onLoadEnd, width }) => {
         );
       });
     }
-    if (ind === 2) {
-      // save to local
-      _saveImage(selectedImage);
-    }
+    // if (ind === 2) {
+    //   // save to local
+    //   _saveImage(selectedImage);
+    // }
 
     setSelectedImage(null);
   };
@@ -334,11 +334,11 @@ const PostBody = ({ body, metadata, onLoadEnd, width }) => {
         options={[
           intl.formatMessage({ id: 'post.copy_link' }),
           intl.formatMessage({ id: 'post.gallery_mode' }),
-          intl.formatMessage({ id: 'post.save_to_local' }),
+          // intl.formatMessage({ id: 'post.save_to_local' }),
           intl.formatMessage({ id: 'alert.cancel' }),
         ]}
         title={intl.formatMessage({ id: 'post.image' })}
-        cancelButtonIndex={3}
+        cancelButtonIndex={2}
         onPress={(index) => {
           handleImagePress(index);
         }}

--- a/src/components/postHtmlRenderer/postInteractionHandler.tsx
+++ b/src/components/postHtmlRenderer/postInteractionHandler.tsx
@@ -164,10 +164,10 @@ export const PostHtmlInteractionHandler = forwardRef(
           );
         });
       }
-      if (ind === 2) {
-        // save to local
-        _saveImage(selectedImage);
-      }
+      // if (ind === 2) {
+      //   // save to local
+      //   _saveImage(selectedImage);
+      // }
 
       setSelectedImage(null);
     };
@@ -246,11 +246,11 @@ export const PostHtmlInteractionHandler = forwardRef(
           options={[
             intl.formatMessage({ id: 'post.copy_link' }),
             intl.formatMessage({ id: 'post.gallery_mode' }),
-            intl.formatMessage({ id: 'post.save_to_local' }),
+            // intl.formatMessage({ id: 'post.save_to_local' }),
             intl.formatMessage({ id: 'alert.cancel' }),
           ]}
           title={intl.formatMessage({ id: 'post.image' })}
-          cancelButtonIndex={3}
+          cancelButtonIndex={2}
           onPress={(index) => {
             _handleImageOptionPress(index);
           }}


### PR DESCRIPTION
### What does this PR?
facing issues reviving save option, was taking too much time, removed for now until we integrate `expo-image`

### Screenshots/Video
<img width="217" alt="Screenshot 2024-03-01 at 21 23 59" src="https://github.com/ecency/ecency-mobile/assets/6298342/b574bd3e-d578-462e-a7eb-633e90e8577b">
