### PR TITLE
integrate external url polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 import { AppRegistry, LogBox } from 'react-native';
 import AppCenter from 'appcenter';
 import { name as appName } from './app.json';
+
+import 'react-native-url-polyfill/auto';
 import 'intl';
 import 'intl/locale-data/jsonp/en-US';
 

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "react-native-tus-client": "^1.1.0",
     "react-native-udp": "^4.1.4",
     "react-native-unique-id": "^2.0.0",
+    "react-native-url-polyfill": "^2.0.0",
     "react-native-vector-icons": "^10.0.2",
     "react-native-version": "^4.0.0",
     "react-native-version-number": "^0.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11738,6 +11738,13 @@ react-native-unique-id@^2.0.0:
     "@react-native-community/async-storage" "1.5.0"
     polygoat "1.1.4"
 
+react-native-url-polyfill@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz#db714520a2985cff1d50ab2e66279b9f91ffd589"
+  integrity sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==
+  dependencies:
+    whatwg-url-without-unicode "8.0.0-3"
+
 react-native-vector-icons@^10.0.2:
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-10.0.2.tgz#44724e0787fb13899efce3510698d1ff69aceefb"


### PR DESCRIPTION
### What does this PR?
Apparently react-native have dropped support for URL polyfill that stared producing url parsing related issues both in deep link and html post links. 

Integrating external polyfill package fixed the issue


### Issue number
https://discord.com/channels/@me/920267778190086205/1215513512672100362
https://discord.com/channels/@me/920267778190086205/1222883542401286216

### Screenshots/Video
https://github.com/ecency/ecency-mobile/assets/6298342/3c8f60c9-d744-4f89-92f6-747ddf429974
https://github.com/ecency/ecency-mobile/assets/6298342/e5578d94-9c01-4054-8518-99978150eaac


