### PR TITLE
Nt/img ratio fix

### DIFF
--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -25,10 +25,11 @@ export const AutoHeightImage = ({
   const _initialHeight = useMemo(() => {
     let _height = contentWidth / (16 / 9);
     if (metadata && metadata.image && metadata.image_ratios) {
+
       metadata.image_ratios.forEach((_ratio, index) => {
         const url = metadata.image[index];
 
-        if (url && !Number.isNaN(_ratio)) {
+        if (url && Number.isFinite(_ratio) && _ratio !== 0) {
           const poxifiedUrl = proxifyImageSrc(
             url,
             undefined,
@@ -40,7 +41,6 @@ export const AutoHeightImage = ({
           );
 
           if (imgUrl === poxifiedUrl) {
-            const _ratio = metadata.image_ratios[index];
             _height = contentWidth / _ratio;
           }
         }

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -268,7 +268,7 @@ export const extractMetadata = async ({
               (width, height) => {
                 resolve(width / height);
               },
-              () => resolve(0),
+              () => resolve(NaN),
             );
           });
         })


### PR DESCRIPTION
### What does this PR?
apparently image_ratios in post reported were set to all zeros, that causing infinity img heights. fixed by taking steps below.

- making sure 0 is not processed as ratio
- making sure 0 is not set as ration upon ratio calculation failure


### Issue number
https://discord.com/channels/@me/920267778190086205/1228823626250453062

### Screenshots/Video
https://github.com/ecency/ecency-mobile/assets/6298342/e4834490-3b9f-4e0b-ae8e-25dd09fce895

