### PR TITLE
Nt/private import fix

### DIFF
--- a/src/providers/hive/auth.js
+++ b/src/providers/hive/auth.js
@@ -330,27 +330,27 @@ export const getUpdatedUserData = (userData, data) => {
     masterKey:
       get(userData, 'authType', '') === AUTH_TYPE.MASTER_KEY
         ? encryptKey(data.password, get(data, 'pinCode'))
-        : '',
+        : get(userData, 'masterKey', ''),
     postingKey:
       get(userData, 'authType', '') === AUTH_TYPE.MASTER_KEY ||
-      get(userData, 'authType', '') === AUTH_TYPE.POSTING_KEY
+        get(userData, 'authType', '') === AUTH_TYPE.POSTING_KEY
         ? encryptKey(get(privateKeys, 'postingKey', '').toString(), get(data, 'pinCode'))
-        : '',
+        : get(userData, 'postingKey', ''),
     activeKey:
       get(userData, 'authType', '') === AUTH_TYPE.MASTER_KEY ||
-      get(userData, 'authType', '') === AUTH_TYPE.ACTIVE_KEY
+        get(userData, 'authType', '') === AUTH_TYPE.ACTIVE_KEY
         ? encryptKey(get(privateKeys, 'activeKey', '').toString(), get(data, 'pinCode'))
-        : '',
+        : get(userData, 'activeKey', ''),
     memoKey:
       get(userData, 'authType', '') === AUTH_TYPE.MASTER_KEY ||
-      get(userData, 'authType', '') === AUTH_TYPE.MEMO_KEY
+        get(userData, 'authType', '') === AUTH_TYPE.MEMO_KEY
         ? encryptKey(get(privateKeys, 'memoKey', '').toString(), get(data, 'pinCode'))
-        : '',
+        : get(userData, 'memoKey', ''),
     ownerKey:
       get(userData, 'authType', '') === AUTH_TYPE.MASTER_KEY ||
-      get(userData, 'authType', '') === AUTH_TYPE.OWNER_KEY
+        get(userData, 'authType', '') === AUTH_TYPE.OWNER_KEY
         ? encryptKey(get(privateKeys, 'ownerKey', '').toString(), get(data, 'pinCode'))
-        : '',
+        : get(userData, 'ownerKey', ''),
   };
 };
 

--- a/src/screens/backupKeysScreen/importPrivateKeyModal.tsx
+++ b/src/screens/backupKeysScreen/importPrivateKeyModal.tsx
@@ -43,8 +43,6 @@ export const ImportPrivateKeyModalModal = forwardRef(({}, ref) => {
     getUpdatedUserKeys(currentAccount, data)
       .then((result) => {
         if (result) {
-          // Save user data to Realm DB
-          // await setUserData(updatedUserData);
           // update user data in redux
           dispatch(updateCurrentAccount({ ...result }));
           setShowModal(false);


### PR DESCRIPTION
### What does this PR?
After testing login routines for some time I finally identified a loophole that most probably causing login data getting corrupted.

Essentially if someone logged in with active or posting key and attempts to import any of keys under Manage Authorities section. What was happening is it overwrites all of private keys to the one imported by user after login.

This matches perfectly with one of reported by a user facing similar issue of being logged in with active but not able to use it yet not being logged out as well.

This is also directly related to pinCode related issue affecting the login data since pinCode is perquisite of managing authorities in app

### Steps to reproduce
Login with any key other than master password, import some other key under Manage Authorities

### Issue number

### Screenshots/Video
BEFORE
https://github.com/ecency/ecency-mobile/assets/6298342/a134f7f4-1428-4ce8-a2c8-ef4bec7ea322


AFTER
https://github.com/ecency/ecency-mobile/assets/6298342/c5259d66-311d-4f2e-bc4d-4c9752f2e8a6

