### PR TITLE
making sure announcement alert appear after welcome modal is closed

### DIFF
--- a/src/providers/queries/announcementsQueries.ts
+++ b/src/providers/queries/announcementsQueries.ts
@@ -1,14 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { getAnnouncements } from '../ecency/ecency';
+import VersionNumber from 'react-native-version-number';
 import QUERIES from './queryKeys';
 import { useAppSelector } from '../../hooks';
 import { updateAnnoucementsMeta } from '../../redux/actions/cacheActions';
 import { handleDeepLink, showActionModal } from '../../redux/actions/uiAction';
 import { getPostUrl } from '../../utils/post';
 import { delay } from '../../utils/editor';
+import parseVersionNumber from '../../utils/parseVersionNumber';
 
 const PROMPT_AGAIN_INTERVAL = 48 * 3600 * 1000; // 2 days
 
@@ -16,31 +18,46 @@ export const useAnnouncementsQuery = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
 
+
+  const lastAppVersion = useAppSelector((state) => state.application.lastAppVersion);
+  const appVersion = useMemo(() => VersionNumber.appVersion, [])
+
   const currentAccount = useAppSelector((state) => state.account.currentAccount);
   const announcementsMeta = useAppSelector((state) => state.cache.announcementsMeta);
 
   const announcmentsQuery = useQuery([QUERIES.ANNOUNCEMENTS.GET], getAnnouncements);
 
+
   useEffect(() => {
-    if (announcmentsQuery.data?.length > 0) {
-      const firstAnnounce = announcmentsQuery.data[0];
 
-      const _metaId = `${firstAnnounce.id}_${currentAccount?.username || 'guest'}`;
-
-      const _meta = announcementsMeta && announcementsMeta[_metaId];
-      const curTime = new Date().getTime();
-
-      if (
-        (firstAnnounce.auth && !currentAccount?.username) ||
-        _meta?.processed ||
-        _meta?.lastSeen + PROMPT_AGAIN_INTERVAL > curTime
-      ) {
-        return;
-      }
-
-      _showAnnouncement(firstAnnounce, _metaId);
+    //bypass if it's first launch after new version install/update
+    const _isNewVersionLaunch =
+      !lastAppVersion || parseVersionNumber(lastAppVersion) < parseVersionNumber(appVersion)
+    if (_isNewVersionLaunch) {
+      return;
     }
-  }, [announcmentsQuery.data, currentAccount.username]);
+
+    //bypass if logged in user is required for announcement, skip otherwise
+    const firstAnnounce = announcmentsQuery.data[0];
+    if (firstAnnounce.auth && !currentAccount?.username) {
+      return;
+    }
+
+    //prepare annoucmnet data
+    const _metaId = `${firstAnnounce.id}_${currentAccount?.username || 'guest'}`;
+    const _meta = announcementsMeta && announcementsMeta[_metaId];
+    const curTime = new Date().getTime();
+
+    //bypass if already processed or last prompt limit now expired
+    if (_meta?.processed ||
+      _meta?.lastSeen + PROMPT_AGAIN_INTERVAL > curTime) {
+      return;
+    }
+
+  
+    _showAnnouncement(firstAnnounce, _metaId);
+
+  }, [announcmentsQuery.data, currentAccount.username, lastAppVersion]);
 
   const _showAnnouncement = async (data, metaId) => {
     const _markAsSeen = () => {


### PR DESCRIPTION
### What does this PR?
Apparently on new update/install, announcement modal was appearing on top of welcome modal, which not only felt annoyed, it might have also caused us to lose possible votes during our last rollout, because at this stage app was not ready to process vote and we might have ended up losing it.

What I also suggest is, after some time of rolling out new update should create a new announcement with different ID and content to encourage users to vote again.

To make it less annoying we can even chose to check if target user already voted, let me know.

### Screenshots/Video
BEFORE
<img width="264" alt="Screenshot 2024-04-29 at 17 26 36" src="https://github.com/ecency/ecency-mobile/assets/6298342/dca3647d-3bfe-407a-be62-554df8911ebe">

NOW

https://github.com/ecency/ecency-mobile/assets/6298342/857712e7-52fc-44ae-8263-9820a13d4d74



