### PR TITLE
passing access token as param to announcement query if available

### DIFF
--- a/src/providers/ecency/ecency.ts
+++ b/src/providers/ecency/ecency.ts
@@ -964,9 +964,12 @@ export const getCommentHistory = async (
   }
 };
 
-export const getAnnouncements = async () => {
+export const getAnnouncements = async (accessToken: string) => {
   try {
-    const res = await ecencyApi.get('/private-api/announcements');
+  
+    const params = accessToken ? { code:accessToken } : null
+
+    const res = await ecencyApi.get('/private-api/announcements', { params });
     console.log('announcements fetcehd', res.data);
     if (!res.data) {
       throw new Error('No announcements found!');


### PR DESCRIPTION
### What does this PR?
Passes accessToken as code in params to get announcements request, if user is logged out app will not send access token.

I believe this holds more value in comparison to exclusively checking proposal votes for announcement locally, this approach can serve as a base for sending custom announcements for particular user later on as well.

Let me know if I should still handle proposal votes checking for showing or not showing announcement locally

### Screenshots/Video
**With Access Token**
<img width="869" alt="Screenshot 2024-04-29 at 18 33 52" src="https://github.com/ecency/ecency-mobile/assets/6298342/9d1e0a39-4118-4f23-82fe-0fe97325b197">


**Without Access Token**
<img width="724" alt="Screenshot 2024-04-29 at 18 51 46" src="https://github.com/ecency/ecency-mobile/assets/6298342/6b1d237e-5e0d-4970-af01-338ceff288cd">

