### PR TITLE
keep submit disabled for complete publishing routine

### DIFF
--- a/src/components/quickReplyModal/quickReplyModalContent.tsx
+++ b/src/components/quickReplyModal/quickReplyModalContent.tsx
@@ -65,6 +65,7 @@ export const QuickReplyModalContent = forwardRef(
     const [mediaUrls, setMediaUrls] = useState<string[]>([]);
     const [isUploading, setIsUploading] = useState(false);
     const [mediaModalVisible, setMediaModalVisible] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     const parentAuthor = selectedPost ? selectedPost.author : '';
     const parentPermlink = selectedPost ? selectedPost.permlink : '';
@@ -144,6 +145,12 @@ export const QuickReplyModalContent = forwardRef(
 
     // handle submit reply
     const _submitPost = async () => {
+
+      if(isSubmitting){
+        return;
+      }
+
+      setIsSubmitting(true);
       let _isSuccess = false;
       const _body =
         mediaUrls.length > 0 ? `${commentValue}\n\n ![](${mediaUrls[0]})` : commentValue;
@@ -172,6 +179,7 @@ export const QuickReplyModalContent = forwardRef(
       } else {
         _addQuickCommentIntoCache(); // add comment value into cache if there is error while posting comment
       }
+      setIsSubmitting(false);
     };
 
     const _handleMediaInsert = (data: MediaInsertData[]) => {
@@ -345,7 +353,7 @@ export const QuickReplyModalContent = forwardRef(
               id: _titleId,
             })}
             isDisable={isUploading || bodyLengthExceeded}
-            isLoading={postSubmitter.isSending}
+            isLoading={isSubmitting}
           />
         </View>
       );


### PR DESCRIPTION
### What does this PR?
I was able to virtualise an environment that could lead to potential duplication of waves. Although it may or may not be source of post duplication.
Added redundancy to submit button in an effort to avoid such scenario. Let's put it to test and see if we still encounter more waves duplication or not

### Issue number
ref: https://discord.com/channels/@me/920267778190086205/1240148539548500060

### Screenshots/Video
result of bug recreation under virtualised environment.

<img width="267" alt="Screenshot 2024-05-15 at 14 16 52" src="https://github.com/ecency/ecency-mobile/assets/6298342/694005f2-46fc-4820-8988-3d96432b91aa">

