### PR TITLE
discarding waves with negative rshare and stats properties

### DIFF
--- a/src/providers/queries/postQueries/wavesQueries.ts
+++ b/src/providers/queries/postQueries/wavesQueries.ts
@@ -169,6 +169,7 @@ export const useWavesQuery = (host: string) => {
       throw new Error('Failed to parse waves');
     }
 
+    _threadedComments.filter((item) => item.net_rshares >= 0 && !item.stats?.gray && !item.stats.hide);
     _threadedComments.sort((a, b) => (new Date(a.created) > new Date(b.created) ? -1 : 1));
     _threadedComments.forEach((item) => {
       wavesIndexCollection.current[`${item.author}/${item.permlink}`] = pagePermlink;


### PR DESCRIPTION
filters out waves after fetching, right now only applicable one refresh, implementing this live causes a glitch, can be refined though, but for now this is go to solution.

Unable to test with real data as rshares did not change after I downvoted a comment/wave with two of my test users