### PR TITLE
added missing null check on post.stats

### DIFF
--- a/src/providers/queries/postQueries/wavesQueries.ts
+++ b/src/providers/queries/postQueries/wavesQueries.ts
@@ -221,7 +221,7 @@ export const useWavesQuery = (host: string) => {
         } 
         
         //discard if wave is downvoted or marked gray
-        else if (post.net_rshares < 0 || post.stats?.gray || post.stats.hide) {
+        else if (post.net_rshares < 0 || post.stats?.gray || post.stats?.hide) {
           _status = false
         }
   


### PR DESCRIPTION
### What does this PR?
fixed issue throwing error at users while posting waves. the wave does get posted however, it's when the recently added downvote routine tried to check for muted content on newly posted wave, it throws error

<img width="251" alt="Screenshot 2024-05-29 at 12 39 50" src="https://github.com/ecency/ecency-mobile/assets/6298342/8ee6e865-0ff1-4728-b4db-c94a2a7b1bb2">
