### PR TITLE
slight downgrade to 4.4.0 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1426,11 +1426,11 @@ PODS:
   - toolbar-android (0.2.1):
     - React
   - TUSKit (1.4.2)
-  - VisionCamera (4.4.1):
-    - VisionCamera/Core (= 4.4.1)
-    - VisionCamera/React (= 4.4.1)
-  - VisionCamera/Core (4.4.1)
-  - VisionCamera/React (4.4.1):
+  - VisionCamera (4.4.0):
+    - VisionCamera/Core (= 4.4.0)
+    - VisionCamera/React (= 4.4.0)
+  - VisionCamera/Core (4.4.0)
+  - VisionCamera/React (4.4.0):
     - React-Core
   - Yoga (1.14.0)
 
@@ -1971,7 +1971,7 @@ SPEC CHECKSUMS:
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   toolbar-android: 2a73856e98b750d7e71ce4644d3f41cc98211719
   TUSKit: 4bcc2fe13e1b4d6c3bfbaca57d64e64c1be31201
-  VisionCamera: 21e2ec4cda0955d40589e939042af275e149dbf9
+  VisionCamera: 7606673f2384ef7216c040601ac4d88b3c425584
   Yoga: 13c8ef87792450193e117976337b8527b49e8c03
 
 PODFILE CHECKSUM: 6d3e6586d42468a95935db6d58480cb8ba9b2218

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "react-native-version": "^4.0.0",
     "react-native-version-number": "^0.3.5",
     "react-native-video": "^5.2.0",
-    "react-native-vision-camera": "^4.4.1",
+    "react-native-vision-camera": "4.4.0",
     "react-native-webview": "^11.26.0",
     "react-native-youtube-iframe": "^2.2.2",
     "react-navigation-redux-helpers": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11740,10 +11740,10 @@ react-native-video@^5.2.0:
     prop-types "^15.7.2"
     shaka-player "^2.5.9"
 
-react-native-vision-camera@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-4.4.1.tgz#5531b9410d7041304a1a9746b455f793bb7df935"
-  integrity sha512-pWuO+AMwQzMoZ85pOHv4P4G1kPdYGA1QAC26rtGfVBbjZt5UyEpYRTirzRhetkQ7meaBjHIWEE/5Qmo0VockHA==
+react-native-vision-camera@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-4.4.0.tgz#6c4c30db0abfc9bbb93d4bb21cce3c2c1878202d"
+  integrity sha512-BXcSGJY0Ox4rYCiSRUykGy/uzLTUGldLN9Qcc9eYBWG+SKmisoE8oBaDbZbcC7VJEEpmN88NfLp9Sq1+DRXjhg==
 
 react-native-webview@^11.26.0:
   version "11.26.1"


### PR DESCRIPTION
### What does this PR?
in latest 4.4.1 version a bug is introduced that is affecting iOS side, the issue is very recent and still under discussion on GH, locking package to 4.4.0 as suggested by fellows devs in GH thread.
