### PR TITLE
multiline title fix

### DIFF
--- a/src/screens/editor/screen/editorScreen.tsx
+++ b/src/screens/editor/screen/editorScreen.tsx
@@ -333,7 +333,7 @@ class EditorScreen extends Component {
   _handleChangeTitle = (text) => {
     const { fields: _fields } = this.state;
 
-    _fields.title = text;
+    _fields.title = text.replace('\n', ' ');
 
     this.setState({ fields: _fields }, () => {
       this._handleFormUpdate('title', _fields.title);


### PR DESCRIPTION
### What does this PR?
in app there is no direct way of making title multiline, however if I copy content from a different app app let's it pass, apparently this is what this user did in his [post ](https://ecency.com/hive-120026/@andres0908/tgnyrnyuyk) as well. Based on this assumption I have added a tiny clause to handle such case.

![Screenshot 2024-07-17 205527](https://github.com/user-attachments/assets/281d3bff-e5a2-447f-a55a-e071163aa691)

### Issue number
https://discord.com/channels/@me/920267778190086205/1261691798443659386

### Screenshots/Video

https://github.com/user-attachments/assets/e538b089-dd26-47d5-8c6b-429e53610146


