### PR TITLE
updated hook dependencies for better polls loading

### DIFF
--- a/src/components/postPoll/container/postPoll.tsx
+++ b/src/components/postPoll/container/postPoll.tsx
@@ -88,13 +88,13 @@ export const PostPoll = ({ author, permlink, metadata, initMode, compactView }: 
   }, [metadata, userVote]);
 
   useEffect(() => {
-    if (pollsQuery.isSuccess && pollsQuery.data) {
+    if (!pollsQuery.isLoading) {
       setMode(!!userVote || _expired ? PollModes.RESULT : PollModes.SELECT);
       setInterpretation(
         pollsQuery.data?.preferred_interpretation || PollPreferredInterpretation.NUMBER_OF_VOTES,
       );
     }
-  }, [pollsQuery.isLoading, userVote]);
+  }, [pollsQuery.data, userVote]);
 
   const _handleCastVote = () => {
     votePollMutation.mutate({ choices: selection });


### PR DESCRIPTION
### What does this PR?
apparently on first time poll load, there is usually a gap between with the isLoading flag is updated and query data is available that was causing a permanent loading indicator on poll options.
