### PR TITLE
[Imp] hide charts by default and toggle visibility based on user selection 

### DIFF
--- a/src/screens/assetDetails/children/children.styles.ts
+++ b/src/screens/assetDetails/children/children.styles.ts
@@ -143,4 +143,11 @@ export default EStyleSheet.create({
     textDecorationLine: 'underline',
     textDecorationColor: '$primaryDarkText',
   },
+  percentEyeContainer: {
+    flexDirection: 'row',
+  },
+  eyeIcon: {
+    color: '$iconColor',
+    marginLeft: 12,
+  },
 });

--- a/src/screens/assetDetails/children/coinBasics.tsx
+++ b/src/screens/assetDetails/children/coinBasics.tsx
@@ -1,9 +1,10 @@
 import React, { Fragment } from 'react';
 import { useIntl } from 'react-intl';
-import { View, Text } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { AssetIcon } from '../../../components/atoms';
 import { DataPair } from '../../../redux/reducers/walletReducer';
 import styles from './children.styles';
+import { Icon } from '../../../components/index';
 
 interface CoinBasicsProps {
   assetId: string;
@@ -13,6 +14,9 @@ interface CoinBasicsProps {
   percentChange: number;
   iconUrl?: string;
   isEngine: boolean;
+  isRenderChart?: boolean;
+  showChart: boolean;
+  setShowChart: (value: boolean) => void;
   onInfoPress: (id: string) => void;
 }
 
@@ -24,6 +28,9 @@ export const CoinBasics = ({
   percentChange,
   iconUrl,
   isEngine,
+  isRenderChart,
+  showChart,
+  setShowChart,
   onInfoPress,
 }: CoinBasicsProps) => {
   const intl = useIntl();
@@ -39,19 +46,28 @@ export const CoinBasics = ({
         />
         <Text style={styles.textCoinTitle}>{coinSymbol}</Text>
       </View>
-
-      {percentChange ? (
-        <Text style={styles.textHeaderChange}>
-          {intl.formatMessage({ id: 'wallet.change' })}
-          <Text style={percentChange > 0 ? styles.textPositive : styles.textNegative}>
-            {percentChange
-              ? ` ${percentChange >= 0 ? '+' : ''}${percentChange.toFixed(1)}%`
-              : ' ---'}
+      <TouchableOpacity style={styles.percentEyeContainer} onPress={() => setShowChart(!showChart)}>
+        {percentChange ? (
+          <Text style={styles.textHeaderChange}>
+            {intl.formatMessage({ id: 'wallet.change' })}
+            <Text style={percentChange > 0 ? styles.textPositive : styles.textNegative}>
+              {percentChange
+                ? ` ${percentChange >= 0 ? '+' : ''}${percentChange.toFixed(1)}%`
+                : ' ---'}
+            </Text>
           </Text>
-        </Text>
-      ) : (
-        <View style={styles.textHeaderChange} />
-      )}
+        ) : (
+          <View style={styles.textHeaderChange} />
+        )}
+        {!!isRenderChart && (
+          <Icon
+            iconType="Ionicons"
+            name={showChart ? 'eye' : 'eye-off'}
+            style={styles.eyeIcon}
+            size={20}
+          />
+        )}
+      </TouchableOpacity>
     </>
   );
 

--- a/src/screens/assetDetails/children/coinSummary.tsx
+++ b/src/screens/assetDetails/children/coinSummary.tsx
@@ -1,5 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { CoinActions, CoinBasics, CoinChart } from '.';
 import { FormattedCurrency } from '../../../components';
 import { ASSET_IDS } from '../../../constants/defaultAssets';
@@ -10,6 +16,8 @@ export interface CoinSummaryProps {
   coinSymbol: string;
   coinData: CoinData;
   percentChagne: number;
+  showChart: boolean;
+  setShowChart: (value: boolean) => void;
   onActionPress: (action: string) => void;
   onInfoPress: (dataKey: string) => void;
 }
@@ -19,6 +27,8 @@ export const CoinSummary = ({
   id,
   coinData,
   percentChagne,
+  showChart,
+  setShowChart,
   onActionPress,
   onInfoPress,
 }: CoinSummaryProps) => {
@@ -46,6 +56,28 @@ export const CoinSummary = ({
   }
 
   const _shRrenderChart = id !== ASSET_IDS.ECENCY && id !== ASSET_IDS.HP && !coinData.isSpk;
+  const animationProgress = useSharedValue(showChart ? 1 : 0);
+
+  useEffect(() => {
+    animationProgress.value = withTiming(showChart ? 1 : 0, {
+      duration: 300,
+      easing: Easing.inOut(Easing.ease),
+    });
+  }, [showChart]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      opacity: animationProgress.value,
+      transform: [{ translateY: (1 - animationProgress.value) * -50 }],
+      height: animationProgress.value * 270, // Adjust this value based on your chart's height
+    };
+  });
+
+  const _renderCoinChart = () => (
+    <Animated.View style={animatedStyle}>
+      {showChart && <CoinChart coinId={id} isEngine={coinData.isEngine} />}
+    </Animated.View>
+  );
 
   return (
     <View>
@@ -58,9 +90,12 @@ export const CoinSummary = ({
         percentChange={percentChagne}
         isEngine={coinData.isEngine}
         onInfoPress={onInfoPress}
+        showChart={showChart}
+        setShowChart={setShowChart}
+        isRenderChart={_shRrenderChart}
       />
       <CoinActions actions={actions} onActionPress={onActionPress} />
-      {_shRrenderChart && <CoinChart coinId={id} isEngine={coinData.isEngine} />}
+      {_shRrenderChart && _renderCoinChart()}
     </View>
   );
 };

--- a/src/screens/assetDetails/screen/assetDetailsScreen.tsx
+++ b/src/screens/assetDetails/screen/assetDetailsScreen.tsx
@@ -52,6 +52,7 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
 
   // state
   const [symbol] = useState(selectedCoins.find((item) => item.id === coinId).symbol);
+  const [showChart, setShowChart] = useState(false);
 
   // side-effects
   useEffect(() => {
@@ -189,6 +190,8 @@ const AssetDetailsScreen = ({ navigation, route }: AssetDetailsScreenProps) => {
       percentChagne={(quote ? quote.percentChange : coinData?.percentChange) || 0}
       onActionPress={_onActionPress}
       onInfoPress={_onInfoPress}
+      showChart={showChart}
+      setShowChart={setShowChart}
     />
   );
 

--- a/src/screens/wallet/children/assetCard.tsx
+++ b/src/screens/wallet/children/assetCard.tsx
@@ -3,8 +3,7 @@ import React, { ComponentType } from 'react';
 import { useIntl } from 'react-intl';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import styles from '../styles/children.styles';
-import { IconButton, SimpleChart } from '../../../components';
-import getWindowDimensions from '../../../utils/getWindowDimensions';
+import { IconButton } from '../../../components';
 import { ASSET_IDS } from '../../../constants/defaultAssets';
 import { ClaimButton } from './claimButton';
 
@@ -12,15 +11,15 @@ import { AssetIcon } from '../../../components/atoms';
 
 export interface AssetCardProps {
   id: string;
-  chartData: number[];
+  // chartData: number[];
   name: string;
   iconUrl?: string;
-  notCrypto?: boolean;
+  // notCrypto?: boolean;
   isEngine?: boolean;
   isSpk?: boolean;
   symbol: string;
   currencySymbol: string;
-  changePercent: number;
+  // changePercent: number;
   currentValue: number;
   ownedBalance: number;
   unclaimedRewards: string;
@@ -39,13 +38,10 @@ export const AssetCard = ({
   id,
   name,
   iconUrl,
-  notCrypto,
   isEngine,
   isSpk,
-  chartData,
   currencySymbol,
   symbol,
-  changePercent,
   currentValue,
   ownedBalance,
   footerComponent,
@@ -125,7 +121,7 @@ export const AssetCard = ({
           isClaiming={isClaiming}
           containerStyle={{
             ...styles.claimContainer,
-            marginBottom: id === ASSET_IDS.ECENCY ? 0 : 16,
+            marginBottom: id === ASSET_IDS.ECENCY || id === ASSET_IDS.HP ? 0 : 16,
           }}
           onPress={_onClaimPress}
         />
@@ -144,43 +140,12 @@ export const AssetCard = ({
     }
   };
 
-  const _renderGraph = () => {
-    if (!chartData.length) {
-      return null;
-    }
-    const _baseWidth = getWindowDimensions().width - 32;
-    return (
-      <View style={styles.chartContainer}>
-        <SimpleChart
-          data={chartData.slice(0, 24)}
-          baseWidth={_baseWidth}
-          showLine={false}
-          chartHeight={60}
-        />
-      </View>
-    );
-  };
-
-  const _renderFooter =
-    chartData.length > 0 ? (
-      <View style={styles.cardFooter}>
-        <Text style={styles.textCurValue}>{`${currencySymbol} ${currentValue.toFixed(2)}`}</Text>
-        <Text style={changePercent > 0 ? styles.textDiffPositive : styles.textDiffNegative}>
-          {`${changePercent >= 0 ? '+' : ''}${changePercent.toFixed(1)}%`}
-        </Text>
-      </View>
-    ) : (
-      <View style={{ height: 12 }} />
-    );
-
   return (
     <TouchableOpacity onPress={onCardPress}>
       <View style={styles.cardContainer}>
         {_renderHeader}
         {_renderBoostAccount()}
         {_renderClaimSection()}
-        {!notCrypto && !isSpk && _renderGraph()}
-        {!notCrypto ? _renderFooter : <View style={{ height: 12 }} />}
         {footerComponent && footerComponent}
       </View>
     </TouchableOpacity>

--- a/src/screens/wallet/screen/walletScreen.tsx
+++ b/src/screens/wallet/screen/walletScreen.tsx
@@ -177,8 +177,8 @@ const WalletScreen = ({ navigation }) => {
     const _isClaimingThis = claimRewardsMutation.checkIsClaiming(item.id);
     const _isClaimingAny = claimRewardsMutation.checkIsClaiming();
 
-    const _tokenMarketData: number[] =
-      priceHistories && priceHistories[item.id] ? priceHistories[item.id].data : [];
+    // const _tokenMarketData: number[] =
+    //   priceHistories && priceHistories[item.id] ? priceHistories[item.id].data : [];
     const quote = quotes && quotes[item.id];
 
     const _balance = coinData.balance + (coinData.savings || 0);
@@ -212,7 +212,7 @@ const WalletScreen = ({ navigation }) => {
       <AssetCard
         name={coinData.name}
         iconUrl={coinData.iconUrl}
-        chartData={_tokenMarketData || []}
+        // chartData={_tokenMarketData || []}
         currentValue={quote?.price || coinData?.currentPrice || 0}
         changePercent={percentChange || 0}
         currencySymbol={currency.currencySymbol}

--- a/src/screens/wallet/styles/children.styles.ts
+++ b/src/screens/wallet/styles/children.styles.ts
@@ -11,13 +11,13 @@ export default EStyleSheet.create({
     overflow: 'hidden',
     borderWidth: 2,
     borderColor: '$primaryLightBackground',
+    paddingVertical: 16,
   } as ViewStyle,
 
   cardHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 16,
-    paddingTop: 16,
     zIndex: 10,
   } as ViewStyle,
 


### PR DESCRIPTION
### What does this PR?
-  removed chart from wallet screen
-  toggle chart visibility in assetDetailsScreen
-  added toggle animation

### Issue number
https://discord.com/channels/@me/920267778190086205/1273221543874265098

### Screenshots/Video

https://github.com/user-attachments/assets/49e7c95a-4bb7-4221-9fb9-a03c60a96bc1

