### PR TITLE
feed refresh fine tune

### DIFF
--- a/src/components/postsList/container/postsListContainer.tsx
+++ b/src/components/postsList/container/postsListContainer.tsx
@@ -238,7 +238,7 @@ const postsListContainer = (
         showsVerticalScrollIndicator={false}
         renderItem={_renderItem}
         keyExtractor={(content, index) => `${content.author}/${content.permlink}-${index}`}
-        onEndReachedThreshold={1}
+        onEndReachedThreshold={0.7}
         maxToRenderPerBatch={5}
         initialNumToRender={3}
         estimatedItemSize={609}

--- a/src/components/tabbedPosts/view/tabContent.tsx
+++ b/src/components/tabbedPosts/view/tabContent.tsx
@@ -211,7 +211,7 @@ const TabContent = ({
 
     const result = await loadPosts(options);
     if (_isMounted && result) {
-      if (shouldReset || isFirstCall) {
+      if (isFirstCall) {
         setPosts([]);
       }
       _postProcessLoadResult(result);


### PR DESCRIPTION
### What does this PR?
Avoid momentary setting feed to empty before pushing new posts on refresh. the momentary setting was triggering a parallel fetch call for posts, 

My assessments point towards that parallel fetch overriding the new content with old paginated cache. Since I was not able to recreate the issue but based my line by line analysis, I believe this was indeed an issue. testing would reveal more results

To avoid future complexities, perhaps we should migrated the ancient feed manager with react-query

### Issue number
https://discord.com/channels/@me/920267778190086205/1273017108048904252

### Screenshots/Video
https://github.com/user-attachments/assets/5a4d6599-1dab-4c23-b093-1bfc068b53b9

