### PR TITLE
Nt/beneficiary extraction

### DIFF
--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -748,6 +748,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
           fields,
           scheduleDate,
           jsonMeta,
+          beneficiaries,
         });
       } else {
         await postContent(
@@ -1188,13 +1189,12 @@ class EditorContainer extends Component<EditorContainerProps, any> {
   _setScheduledPost = (data) => {
     const { dispatch, intl, currentAccount, navigation } = this.props;
     const { rewardType } = this.state;
-    const beneficiaries = this._extractBeneficiaries();
 
     const options = makeOptions({
       author: data.author,
       permlink: data.permlink,
       operationType: rewardType,
-      beneficiaries,
+      beneficiaries: data.beneficiaries,
     });
 
     addSchedule(

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -1,5 +1,6 @@
 import { diff_match_patch as diffMatchPatch } from 'diff-match-patch';
 import MimeTypes from 'mime-types';
+import { unionBy } from 'lodash';
 import { Image } from 'react-native';
 import VersionNumber from 'react-native-version-number';
 import getSlug from 'speakingurl';
@@ -94,8 +95,8 @@ export const generateUniquePermlink = (prefix) => {
   const timeFormat = `${t.getFullYear().toString()}${(t.getMonth() + 1).toString()}${t
     .getDate()
     .toString()}t${t.getHours().toString()}${t.getMinutes().toString()}${t
-    .getSeconds()
-    .toString()}${t.getMilliseconds().toString()}z`;
+      .getSeconds()
+      .toString()}${t.getMilliseconds().toString()}z`;
 
   return `${prefix}-${timeFormat}`;
 };
@@ -112,35 +113,31 @@ export const makeOptions = (postObj) => {
     permlink: postObj.permlink,
     max_accepted_payout: '1000000.000 HBD',
     percent_hbd: 10000,
-    extensions: [],
+    extensions: [] as any,
   };
+
+
+
   switch (postObj.operationType) {
     case 'sp':
       a.max_accepted_payout = '1000000.000 HBD';
       a.percent_hbd = 0;
-      if (postObj.beneficiaries && postObj.beneficiaries.length > 0) {
-        postObj.beneficiaries.sort((a, b) => a.account.localeCompare(b.account));
-        a.extensions = [[0, { beneficiaries: postObj.beneficiaries }]];
-      }
       break;
 
     case 'dp':
       a.max_accepted_payout = '0.000 HBD';
       a.percent_hbd = 10000;
-      if (postObj.beneficiaries && postObj.beneficiaries.length > 0) {
-        postObj.beneficiaries.sort((a, b) => a.account.localeCompare(b.account));
-        a.extensions = [[0, { beneficiaries: postObj.beneficiaries }]];
-      }
       break;
 
     default:
       a.max_accepted_payout = '1000000.000 HBD';
       a.percent_hbd = 10000;
-      if (postObj.beneficiaries && postObj.beneficiaries.length > 0) {
-        postObj.beneficiaries.sort((a, b) => a.account.localeCompare(b.account));
-        a.extensions = [[0, { beneficiaries: postObj.beneficiaries }]];
-      }
       break;
+  }
+
+  if (postObj.beneficiaries && postObj.beneficiaries.length > 0) {
+    postObj.beneficiaries.sort((a, b) => a.account.localeCompare(b.account));
+    a.extensions = [[0, { beneficiaries: unionBy(postObj.beneficiaries, 'account') }]];
   }
 
   return a;

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -95,8 +95,8 @@ export const generateUniquePermlink = (prefix) => {
   const timeFormat = `${t.getFullYear().toString()}${(t.getMonth() + 1).toString()}${t
     .getDate()
     .toString()}t${t.getHours().toString()}${t.getMinutes().toString()}${t
-      .getSeconds()
-      .toString()}${t.getMilliseconds().toString()}z`;
+    .getSeconds()
+    .toString()}${t.getMilliseconds().toString()}z`;
 
   return `${prefix}-${timeFormat}`;
 };
@@ -115,8 +115,6 @@ export const makeOptions = (postObj) => {
     percent_hbd: 10000,
     extensions: [] as any,
   };
-
-
 
   switch (postObj.operationType) {
     case 'sp':


### PR DESCRIPTION
### What does this PR?
Based on my assessments, apparently it is not sorting that was causing the issue but having duplicate beneficiary possibly returned in videoMetadata as we do also inject one default beneficiary manually as well.
<img width="762" alt="Screenshot 2024-08-27 at 17 20 06" src="https://github.com/user-attachments/assets/4a1c52b3-90e8-45e5-bcdd-e9718a03196d">

Moreover my forced duplication test also produced expected error based on my assessment above. message only talks about sorting order and not pointing toward duplication, which is the issue with my test case.
<img width="952" alt="Screenshot 2024-08-27 at 17 12 09" src="https://github.com/user-attachments/assets/0eb25db7-9fac-4fe5-b5c8-fa8f2a5490ce">

Updated makeOptions method to discard any duplicated beneficiary along with sorting them out.
Also, this PR handle the passing of already extracted beneficiaries to schedule post routing.

### Issue number
https://discord.com/channels/@me/920267778190086205/1277127392997146665

### Screenshots/Video
Successful publishing of same draft that was failing with existing code.
<img width="990" alt="Screenshot 2024-08-27 at 17 13 42" src="https://github.com/user-attachments/assets/4d7e4d17-e930-465f-a250-fb08745de07f">
