### PR TITLE
{Bug Fix] quick profile modal UI issue on larger font settings

### DIFF
--- a/src/components/organisms/quickProfileModal/children/profileStats.tsx
+++ b/src/components/organisms/quickProfileModal/children/profileStats.tsx
@@ -39,7 +39,12 @@ export const ProfileStats = ({ data, horizontalMargin, intermediate }: Props) =>
 const StatItem = (props: { label: string; value: number | string; intermediate: boolean }) => (
   <View style={{ alignItems: 'center', flex: 1 }}>
     {!props.intermediate ? (
-      <Animated.Text entering={BounceIn} exiting={BounceOut} style={styles.statValue}>
+      <Animated.Text
+        entering={BounceIn}
+        exiting={BounceOut}
+        style={styles.statValue}
+        allowFontScaling={false}
+      >
         {props.value}
       </Animated.Text>
     ) : (


### PR DESCRIPTION

### What does this PR?
This PR fixes  UI issue in quick profile modal which was being cropped from bottom when larger font settings are applied on 

### Steps to reproduce
change device font settings to larger font sizes and open quick profile modal

### Issue number
https://discord.com/channels/@me/920267778190086205/1295153546941042698

### Screenshots/Video
<img width="335" alt="image" src="https://github.com/user-attachments/assets/a999553f-c721-4706-933d-3403a6523636">
<img width="335" alt="image" src="https://github.com/user-attachments/assets/99c31b29-8c1d-4657-b5cf-b1c9257032e9">

