### PR TITLE
Nt/preserving poll

### DIFF
--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -30,6 +30,7 @@ type Props = {
   paramFiles: any[];
   isEditing: boolean;
   isPreviewActive: boolean;
+  isEditMode: boolean
   setIsUploading: (isUploading: boolean) => void;
   handleMediaInsert: (data: MediaInsertData[]) => void;
   handleOnAddLinkPress: () => void;
@@ -44,6 +45,7 @@ export const EditorToolbar = ({
   paramFiles,
   isEditing,
   isPreviewActive,
+  isEditMode,
   setIsUploading,
   handleMediaInsert,
   handleOnAddLinkPress,
@@ -284,14 +286,20 @@ export const EditorToolbar = ({
               name="text-short"
             />
 
-            <IconButton
-              size={18}
-              style={[styles.rightIcons, !!pollDraft?.title && styles.iconBottomBar]}
-              iconStyle={styles.icon}
-              iconType="SimpleLineIcons"
-              name="chart"
-              onPress={_showPollsExtension}
-            />
+            {
+              !isEditMode && (
+                <IconButton
+                  size={18}
+                  style={[styles.rightIcons, !!pollDraft?.title && styles.iconBottomBar]}
+                  iconStyle={styles.icon}
+                  iconType="SimpleLineIcons"
+                  name="chart"
+                  onPress={_showPollsExtension}
+                />
+              )
+
+            }
+
 
             <IconButton
               onPress={_showImageUploads}

--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -30,7 +30,7 @@ type Props = {
   paramFiles: any[];
   isEditing: boolean;
   isPreviewActive: boolean;
-  isEditMode: boolean
+  isEditMode: boolean;
   setIsUploading: (isUploading: boolean) => void;
   handleMediaInsert: (data: MediaInsertData[]) => void;
   handleOnAddLinkPress: () => void;
@@ -286,20 +286,16 @@ export const EditorToolbar = ({
               name="text-short"
             />
 
-            {
-              !isEditMode && (
-                <IconButton
-                  size={18}
-                  style={[styles.rightIcons, !!pollDraft?.title && styles.iconBottomBar]}
-                  iconStyle={styles.icon}
-                  iconType="SimpleLineIcons"
-                  name="chart"
-                  onPress={_showPollsExtension}
-                />
-              )
-
-            }
-
+            {!isEditMode && (
+              <IconButton
+                size={18}
+                style={[styles.rightIcons, !!pollDraft?.title && styles.iconBottomBar]}
+                iconStyle={styles.icon}
+                iconType="SimpleLineIcons"
+                name="chart"
+                onPress={_showPollsExtension}
+              />
+            )}
 
             <IconButton
               onPress={_showImageUploads}

--- a/src/components/markdownEditor/view/markdownEditorView.tsx
+++ b/src/components/markdownEditor/view/markdownEditorView.tsx
@@ -447,6 +447,7 @@ const MarkdownEditorView = ({
           postBody={bodyTextRef.current}
           isPreviewActive={isPreviewActive}
           paramFiles={paramFiles}
+          isEditMode={isEdit}
           setIsUploading={setIsUploading}
           handleMediaInsert={_handleMediaInsert}
           handleOnAddLinkPress={_handleOnAddLinkPress}

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -961,6 +961,8 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         videoThumbUrls: speakContentBuilder.thumbUrlsRef.current,
         thumbUrl,
         fetchRatios: true,
+        postType: jsonMetadata.type,
+        contentType: jsonMetadata.content_type
       });
 
       let jsonMeta = {};

--- a/src/screens/editor/container/editorContainer.tsx
+++ b/src/screens/editor/container/editorContainer.tsx
@@ -962,7 +962,7 @@ class EditorContainer extends Component<EditorContainerProps, any> {
         thumbUrl,
         fetchRatios: true,
         postType: jsonMetadata.type,
-        contentType: jsonMetadata.content_type
+        contentType: jsonMetadata.content_type,
       });
 
       let jsonMeta = {};

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -229,6 +229,7 @@ export const extractMetadata = async ({
   videoThumbUrls,
   fetchRatios,
   postType,
+  contentType,
   videoPublishMeta,
   pollDraft,
 }: {
@@ -237,6 +238,7 @@ export const extractMetadata = async ({
   videoThumbUrls: string[];
   fetchRatios?: boolean;
   postType?: PostTypes;
+  contentType?: ContentType;
   videoPublishMeta?: ThreeSpeakVideo;
   pollDraft?: PollDraft;
 }) => {
@@ -244,7 +246,7 @@ export const extractMetadata = async ({
   // const userReg = /(^|\s)(@[a-z][-.a-z\d]+[a-z\d])/gim;
 
   let out: PostMetadata = {
-    content_type: ContentType.GENERAL,
+    content_type: contentType || ContentType.GENERAL,
   };
 
   const mUrls = extractUrls(body);


### PR DESCRIPTION
### What does this PR?
Preserves poll after wave editing
1. keeps the content type and post type properties from old jsonMeta
2. hides poll wizard from post edit mode to restrict users from updating or adding poll in edit mode


### Issue number
https://discord.com/channels/@me/920267778190086205/1299968103601541200

### Screenshots/Video
This is an edited version of wave with preserved poll data
![Screenshot 2024-10-28 at 17 11 33](https://github.com/user-attachments/assets/3a4c4ecd-eeb9-4754-8db2-7edbe7785ea0)
