### PR TITLE
updated spinner tags style to keep them always centered to spinner

### DIFF
--- a/src/components/spinGame/spinGameStyles.js
+++ b/src/components/spinGame/spinGameStyles.js
@@ -27,16 +27,23 @@ export default EStyleSheet.create({
   },
   spinnerWrapper: {
     flex: 1,
+    width: '100%',
     marginTop: 10,
   },
-  backgroundTags: {
+  backgroundTagsWrapper: {
     position: 'absolute',
-    width: '100%',
-    height: 360,
     left: 0,
-    top: 16,
+    top: 0,
     right: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+    alignSelf: 'center',
     zIndex: 998,
+  },
+  backgroundTags: {
+    width: 400,
+    height: 360,
   },
   descriptionWrapper: {
     backgroundColor: '$primaryDarkBlue',

--- a/src/components/spinGame/spinGameView.js
+++ b/src/components/spinGame/spinGameView.js
@@ -60,10 +60,14 @@ const SpinGameView = ({
             </Fragment>
           )}
         </View>
+
         <View style={styles.spinnerWrapper}>
           {!isSpinning && !isLoading && gameRight > 0 && (
-            <Image source={ESTM_TAGS} style={styles.backgroundTags} />
+            <View style={styles.backgroundTagsWrapper}>
+              <Image source={ESTM_TAGS} resizeMode="contain" style={styles.backgroundTags} />
+            </View>
           )}
+
           <BoostIndicatorAnimation key={gameRight} isSpinning={isSpinning} />
 
           {!isSpinning && score > 0 && (
@@ -75,6 +79,7 @@ const SpinGameView = ({
             </View>
           )}
         </View>
+
         <View style={styles.productWrapper}>
           {!isSpinning && !isLoading && (
             <Fragment>


### PR DESCRIPTION
### What does this PR?
Although the issue was recently introduced during our attempt to avoid using static widths, but the overall logic to render tags was not very promising either.

This new approach makes sure tags are always centred and perfectly sized to the spinners.

### Issue number
https://discord.com/channels/@me/920267778190086205/1313161255435108412

### Screenshots/Video
<img width="264" alt="Screenshot 2024-12-10 at 18 41 05" src="https://github.com/user-attachments/assets/6cfa6ef1-73b4-458a-aabc-cfcf5717c420">
