### PR TITLE
Nt/preserving tokens meta

### DIFF
--- a/src/screens/assetsSelect/screen/assetsSelect.tsx
+++ b/src/screens/assetsSelect/screen/assetsSelect.tsx
@@ -131,10 +131,17 @@ const AssetsSelect = ({ navigation }) => {
         }));
       }
 
+      //extract a list of tokens with meta entry
+      const assetsWithMeta = currentAccount.about.profile.tokens.filter((item) => (!!item.meta))
+
       const updatedCurrentAccountData = currentAccount;
       updatedCurrentAccountData.about.profile = {
         ...updatedCurrentAccountData.about.profile,
-        tokens: assetsData,
+        // make sure entries with meta are preserved
+        tokens: [
+          ...assetsData,
+          ...assetsWithMeta
+        ],
       };
       const params = {
         ...updatedCurrentAccountData.about.profile,

--- a/src/screens/wallet/screen/walletScreen.tsx
+++ b/src/screens/wallet/screen/walletScreen.tsx
@@ -88,14 +88,14 @@ const WalletScreen = ({ navigation }) => {
   const populateSelectedAssets = (tokensArr) => {
     //filter out any other type of token other than ENGINE and SPK
     return tokensArr
-    .filter(({type }) => type === 'ENGINE' || type === 'SPK')
-    .map(({ symbol, type }) => ({
-      id: symbol,
-      symbol,
-      isEngine: type === 'ENGINE',
-      isSpk: type === 'SPK',
-      notCrypto: false,
-    }));
+      .filter(({ type }) => type === 'ENGINE' || type === 'SPK')
+      .map(({ symbol, type }) => ({
+        id: symbol,
+        symbol,
+        isEngine: type === 'ENGINE',
+        isSpk: type === 'SPK',
+        notCrypto: false,
+      }));
   };
 
   const _updateSelectedAssetsDataFromProfileJsonMeta = () => {

--- a/src/screens/wallet/screen/walletScreen.tsx
+++ b/src/screens/wallet/screen/walletScreen.tsx
@@ -86,7 +86,10 @@ const WalletScreen = ({ navigation }) => {
 
   // actions
   const populateSelectedAssets = (tokensArr) => {
-    return tokensArr.map(({ symbol, type }) => ({
+    //filter out any other type of token other than ENGINE and SPK
+    return tokensArr
+    .filter(({type }) => type === 'ENGINE' || type === 'SPK')
+    .map(({ symbol, type }) => ({
       id: symbol,
       symbol,
       isEngine: type === 'ENGINE',


### PR DESCRIPTION
### What does this PR?
- Preserving tokens with meta data while updating list of selected assets
- Ignoring any other token type uptill we add support for them, in both main wallet screen and asset select screen

NOTE: merging this PR before will remove RN 0.77 upgraded variant currently being alpha tested unless this [upgrade PR](https://github.com/ecency/ecency-mobile/pull/2958) is merged first

### Issue number
https://github.com/orgs/ecency/projects/4/views/1?pane=issue&itemId=101946400

### Screenshots/Video

Example showcasing change in selected assets do not alter the example token data having meta data.
<img width="602" alt="Screenshot 2025-03-14 at 23 53 55" src="https://github.com/user-attachments/assets/d2809729-d560-4867-b85f-954239059146" />
<img width="641" alt="Screenshot 2025-03-14 at 23 55 37" src="https://github.com/user-attachments/assets/17cfda7e-7335-46d2-842a-8fe7ede370e5" />


only displaying ENGINE and SPK asset for now until we add support for processing meta on front end.
<img width="209" alt="Screenshot 2025-03-15 at 00 02 09" src="https://github.com/user-attachments/assets/ce81b37c-771b-41c1-96f8-305c2655e34d" />


