### PR TITLE
fixed android modal issue taking all screen on keyboard open

### DIFF
--- a/src/components/quickReplyModal/quickReplyModalView.tsx
+++ b/src/components/quickReplyModal/quickReplyModalView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ActionSheet from 'react-native-actions-sheet';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { QuickReplyModalContent } from './quickReplyModalContent';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import { hideReplyModal } from '../../redux/actions/uiAction';
@@ -42,6 +42,7 @@ const QuickReplyModal = () => {
         containerStyle={styles.sheetContent}
         indicatorStyle={styles.sheetIndicator}
         defaultOverlayOpacity={0}
+        keyboardHandlerEnabled={Platform.OS !== 'android'} //hack to prevent sheet height issue on android
         onClose={_onClose}
       >
         <QuickReplyModalContent


### PR DESCRIPTION
### What does this PR?
On android the quick replay modal sheet was being pushed to the top of screen when keyboard is opened. This PR fixes this behaviour.

### Issue number
https://github.com/orgs/ecency/projects/4/views/1?pane=issue&itemId=102128626

### Screenshots/Video
BEFORE
![Screenshot 2025-03-19 at 16 28 46](https://github.com/user-attachments/assets/7b61bc67-d4b5-40e7-99fa-c9806d1b1495)


AFTER
![Screenshot 2025-03-19 at 16 28 13](https://github.com/user-attachments/assets/02c50898-87c8-4d41-8872-79b219e1a3c8)
