### PR TITLE
Nt/post img tweaks

### DIFF
--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -3,7 +3,12 @@ import React, { useMemo, useState } from 'react';
 import { Platform, TouchableOpacity } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { Image as ExpoImage } from 'expo-image';
-import Animated, { Easing, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 
 interface AutoHeightImageProps {
   contentWidth: number;
@@ -37,7 +42,7 @@ export const AutoHeightImage = ({
       metadata.image_ratios.forEach((_ratio, index) => {
         const url = metadata.image[index];
 
-        //make sure ratio is of the target image proxified source
+        // make sure ratio is of the target image proxified source
         if (url && Number.isFinite(_ratio) && _ratio !== 0) {
           const poxifiedUrl = proxifyImageSrc(
             url,
@@ -58,7 +63,6 @@ export const AutoHeightImage = ({
     return _height;
   }, [imgUrl]);
 
-
   const [imgWidth, setImgWidth] = useState(contentWidth);
   const imgHeightAnim = useSharedValue(_initialHeight); // Initial height based on 16:9 ratio
   const imgOpacityAnim = useSharedValue(0); // Initial opacity for fade-in effect
@@ -66,8 +70,11 @@ export const AutoHeightImage = ({
 
   // Function to animate the height change using Reanimated
   const animateHeight = (newHeight: number) => {
-    imgHeightAnim.value = withTiming(newHeight, { duration: 300, easing: Easing.out(Easing.circle) }); // Smooth transition over 300ms
-    bgColorAnim.value = withTiming('transparent'), { duration: 200 }; // Smooth transition over 300ms
+    imgHeightAnim.value = withTiming(newHeight, {
+      duration: 300,
+      easing: Easing.out(Easing.circle),
+    }); // Smooth transition over 300ms
+    (bgColorAnim.value = withTiming('transparent')), { duration: 200 }; // Smooth transition over 300ms
   };
 
   // Function to animate the fade-in effect
@@ -77,17 +84,19 @@ export const AutoHeightImage = ({
 
   // NOTE: important to have post image bound set even for images with ratio already provided
   // as this handles the case where width can be lower than contentWidth
-  const _setImageBounds = (width:number, height:number) => {
-    const newWidth = lockWidth ? contentWidth : Math.round(width < contentWidth ? width : contentWidth);
+  const _setImageBounds = (width: number, height: number) => {
+    const newWidth = lockWidth
+      ? contentWidth
+      : Math.round(width < contentWidth ? width : contentWidth);
     const newHeight = Math.round((height / width) * newWidth);
 
-    if(!aspectRatio){
+    if (!aspectRatio) {
       animateHeight(newHeight); // Animate the height change
     }
-   
+
     setImgWidth(newWidth);
 
-    if(!aspectRatio && setAspectRatio){
+    if (!aspectRatio && setAspectRatio) {
       setAspectRatio(newHeight / newWidth);
     }
   };
@@ -97,28 +106,29 @@ export const AutoHeightImage = ({
     width: imgWidth,
     height: imgHeightAnim.value, // Bind animated height
     backgroundColor: bgColorAnim.value,
-    borderRadius:8,
+    borderRadius: 8,
   }));
 
   const animatedImgStyle = useAnimatedStyle(() => ({
     flex: 1,
-    borderRadius:8,
+    borderRadius: 8,
     opacity: imgOpacityAnim.value, // Bind animated opacity
   }));
 
-
   const _onLoad = (evt) => {
     _setImageBounds(evt.source.width, evt.source.height);
-    animateFadeIn()
+    animateFadeIn();
   };
 
   return (
     <TouchableOpacity onPress={onPress} disabled={isAnchored} activeOpacity={activeOpacity || 1}>
       <Animated.View style={animatedWrapperStyle}>
-        <AnimatedExpoImage style={animatedImgStyle}
+        <AnimatedExpoImage
+          style={animatedImgStyle}
           source={{ uri: imgUrl }}
           contentFit="cover"
-          onLoad={_onLoad} />
+          onLoad={_onLoad}
+        />
       </Animated.View>
     </TouchableOpacity>
   );

--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -1,5 +1,5 @@
 import { proxifyImageSrc } from '@ecency/render-helper';
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Platform, TouchableOpacity } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { Image as ExpoImage } from 'expo-image';
@@ -13,6 +13,8 @@ interface AutoHeightImageProps {
   activeOpacity?: number;
   onPress: () => void;
 }
+
+const AnimatedExpoImage = Animated.createAnimatedComponent(ExpoImage);
 
 export const AutoHeightImage = ({
   contentWidth,
@@ -54,40 +56,41 @@ export const AutoHeightImage = ({
   const [imgWidth, setImgWidth] = useState(contentWidth);
   const imgHeightAnim = useSharedValue(_initialHeight); // Initial height based on 16:9 ratio
   const imgOpacityAnim = useSharedValue(0); // Initial opacity for fade-in effect
+  const bgColorAnim = useSharedValue(EStyleSheet.value('$primaryLightBackground')); // Initial back
 
   // Function to animate the height change using Reanimated
   const animateHeight = (newHeight: number) => {
-    imgHeightAnim.value = withTiming(newHeight, { duration: 200, easing:Easing.ease}); // Smooth transition over 300ms
-    
+    imgHeightAnim.value = withTiming(newHeight, { duration: 200, easing: Easing.ease }); // Smooth transition over 300ms
+    bgColorAnim.value = withTiming('transparent'), {duration: 200}; // Smooth transition over 300ms
   };
 
-    // Function to animate the fade-in effect
-    const animateFadeIn = () => {
-      imgOpacityAnim.value = withTiming(1, { duration: 300 }); // Fade in over 500ms
-    };
+  // Function to animate the fade-in effect
+  const animateFadeIn = () => {
+    imgOpacityAnim.value = withTiming(1, { duration: 150 }); // Fade in over 500ms
+  };
 
   // NOTE: important to have post image bound set even for images with ratio already provided
   // as this handles the case where width can be lower than contentWidth
   const _setImageBounds = (width, height) => {
-
     const newWidth = Math.round(width < contentWidth ? width : contentWidth);
     const newHeight = Math.round((height / width) * newWidth);
 
     animateHeight(newHeight); // Animate the height change
     setImgWidth(newWidth);
-
   };
 
   // Use Reanimated to bind the animated height value to the style
-  const animatedStyle = useAnimatedStyle(() => ({
+  const animatedWrapperStyle = useAnimatedStyle(() => ({
+    width: imgWidth,
     height: imgHeightAnim.value, // Bind animated height
+    backgroundColor: bgColorAnim.value,
+  }));
+  
+  const animatedImgStyle = useAnimatedStyle(() => ({
+    flex: 1,
     opacity: imgOpacityAnim.value, // Bind animated opacity
   }));
 
-  const imgStyle = {
-    width: imgWidth,
-    backgroundColor: EStyleSheet.value('$primaryLightBackground'),
-  };
 
   const _onLoad = (evt) => {
     _setImageBounds(evt.source.width, evt.source.height);
@@ -96,12 +99,12 @@ export const AutoHeightImage = ({
 
   return (
     <TouchableOpacity onPress={onPress} disabled={isAnchored} activeOpacity={activeOpacity || 1}>
-      <Animated.View style={[imgStyle, animatedStyle]}>
-        <ExpoImage  style={{ flex: 1 }}
-          source={{ uri: imgUrl }}
-          contentFit="contain"
-          onLoad={_onLoad} />
-      </Animated.View>
+        <Animated.View style={animatedWrapperStyle}>
+          <AnimatedExpoImage style={animatedImgStyle}
+            source={{ uri: imgUrl }}
+            contentFit="contain"
+            onLoad={_onLoad} />
+        </Animated.View>
     </TouchableOpacity>
   );
 };

--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -60,13 +60,13 @@ export const AutoHeightImage = ({
 
   // Function to animate the height change using Reanimated
   const animateHeight = (newHeight: number) => {
-    imgHeightAnim.value = withTiming(newHeight, { duration: 200, easing: Easing.ease }); // Smooth transition over 300ms
-    bgColorAnim.value = withTiming('transparent'), {duration: 200}; // Smooth transition over 300ms
+    imgHeightAnim.value = withTiming(newHeight, { duration: 300, easing: Easing.out(Easing.circle) }); // Smooth transition over 300ms
+    bgColorAnim.value = withTiming('transparent'), { duration: 200 }; // Smooth transition over 300ms
   };
 
   // Function to animate the fade-in effect
   const animateFadeIn = () => {
-    imgOpacityAnim.value = withTiming(1, { duration: 150 }); // Fade in over 500ms
+    imgOpacityAnim.value = withTiming(1, { duration: 200 }); // Fade in over 500ms
   };
 
   // NOTE: important to have post image bound set even for images with ratio already provided
@@ -99,12 +99,12 @@ export const AutoHeightImage = ({
 
   return (
     <TouchableOpacity onPress={onPress} disabled={isAnchored} activeOpacity={activeOpacity || 1}>
-        <Animated.View style={animatedWrapperStyle}>
-          <AnimatedExpoImage style={animatedImgStyle}
-            source={{ uri: imgUrl }}
-            contentFit="contain"
-            onLoad={_onLoad} />
-        </Animated.View>
+      <Animated.View style={animatedWrapperStyle}>
+        <AnimatedExpoImage style={animatedImgStyle}
+          source={{ uri: imgUrl }}
+          contentFit="cover"
+          onLoad={_onLoad} />
+      </Animated.View>
     </TouchableOpacity>
   );
 };

--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -55,10 +55,13 @@ export const AutoHeightImage = ({
   // NOTE: important to have post image bound set even for images with ratio already provided
   // as this handles the case where width can be lower than contentWidth
   const _setImageBounds = (width, height) => {
-    const newWidth = width < contentWidth ? width : contentWidth;
-    const newHeight = (height / width) * newWidth;
+
+    const newWidth = Math.round(width < contentWidth ? width : contentWidth);
+    const newHeight = Math.round((height / width) * newWidth);
+
     setImgHeight(newHeight);
     setImgWidth(newWidth);
+
   };
 
   const imgStyle = {

--- a/src/components/postCard/children/postCardContent.tsx
+++ b/src/components/postCard/children/postCardContent.tsx
@@ -11,6 +11,7 @@ import styles from './postCardStyles';
 import { PostCardActionIds } from '../container/postCard';
 import ROUTES from '../../../constants/routeNames';
 import { ContentType } from '../../../providers/hive/hive.types';
+import { AutoHeightImage } from '../../../components/autoHeightImage/autoHeightImage';
 
 const DEFAULT_IMAGE =
   'https://images.ecency.com/DQmT8R33geccEjJfzZEdsRHpP3VE8pu3peRCnQa1qukU4KR/no_image_3x.png';
@@ -38,11 +39,6 @@ export const PostCardContent = ({
   const dim = useWindowDimensions();
 
   const imgWidth = dim.width - 18;
-  const [calcImgHeight, setCalcImgHeight] = useState(imageRatio ? imgWidth / imageRatio : 300);
-
-  const resizeMode = useMemo(() => {
-    return calcImgHeight < dim.height ? 'contain' : 'cover';
-  }, [dim.height]);
 
   // featured text can be used to add more labels in future by just inserting text as array item
   const _isPollPost =
@@ -67,6 +63,10 @@ export const PostCardContent = ({
     });
   };
 
+  const _setAspectRatio = (ratio: number) => {
+    setImageRatio(content.author + content.permlink, ratio);
+  }
+
   let images = { image: DEFAULT_IMAGE, thumbnail: DEFAULT_IMAGE };
   if (content.thumbnail) {
     if (nsfw !== '0' && content.nsfw) {
@@ -82,24 +82,14 @@ export const PostCardContent = ({
     <View style={styles.postBodyWrapper}>
       <TouchableOpacity activeOpacity={0.8} style={styles.hiddenImages} onPress={_onPress}>
         {!isHideImage && (
-          <ExpoImage
-            source={{ uri: images.image }}
-            style={[
-              styles.thumbnail,
-              {
-                width: imgWidth,
-                height: Math.min(calcImgHeight, dim.height),
-              },
-            ]}
-            contentFit={resizeMode}
-            onLoad={(evt) => {
-              if (!imageRatio) {
-                const _imgRatio = evt.source.width / evt.source.height;
-                const height = imgWidth / _imgRatio;
-                setCalcImgHeight(height);
-                setImageRatio(content.author + content.permlink, _imgRatio);
-              }
-            }}
+          <AutoHeightImage
+            contentWidth={imgWidth}
+            imgUrl={images.image}
+            isAnchored={true}
+            activeOpacity={0.8}
+            aspectRatio={imageRatio}
+            lockWidth={true}
+            setAspectRatio={_setAspectRatio}
           />
         )}
 

--- a/src/components/postCard/children/postCardContent.tsx
+++ b/src/components/postCard/children/postCardContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { TouchableOpacity, Text, View, useWindowDimensions } from 'react-native';
 // Utils
 import { useIntl } from 'react-intl';
@@ -10,7 +10,7 @@ import styles from './postCardStyles';
 import { PostCardActionIds } from '../container/postCard';
 import ROUTES from '../../../constants/routeNames';
 import { ContentType } from '../../../providers/hive/hive.types';
-import { AutoHeightImage } from '../../autoHeightImage/autoHeightImage';
+import { Image as ExpoImage } from 'expo-image';
 
 const DEFAULT_IMAGE =
   'https://images.ecency.com/DQmT8R33geccEjJfzZEdsRHpP3VE8pu3peRCnQa1qukU4KR/no_image_3x.png';
@@ -38,6 +38,11 @@ export const PostCardContent = ({
   const dim = useWindowDimensions();
 
   const imgWidth = dim.width - 18;
+  const [calcImgHeight, setCalcImgHeight] = useState(imageRatio ? imgWidth / imageRatio : 300);
+
+  const resizeMode = useMemo(() => {
+    return calcImgHeight < dim.height ? 'contain' : 'cover';
+  }, [dim.height]);
 
   // featured text can be used to add more labels in future by just inserting text as array item
   const _isPollPost =
@@ -62,9 +67,9 @@ export const PostCardContent = ({
     });
   };
 
-  const _setAspectRatio = (ratio: number) => {
-    setImageRatio(content.author + content.permlink, ratio);
-  };
+  // const _setAspectRatio = (ratio: number) => {
+  //   setImageRatio(content.author + content.permlink, ratio);
+  // };
 
   let images = { image: DEFAULT_IMAGE, thumbnail: DEFAULT_IMAGE };
   if (content.thumbnail) {
@@ -81,14 +86,24 @@ export const PostCardContent = ({
     <View style={styles.postBodyWrapper}>
       <TouchableOpacity activeOpacity={0.8} style={styles.hiddenImages} onPress={_onPress}>
         {!isHideImage && (
-          <AutoHeightImage
-            contentWidth={imgWidth}
-            imgUrl={images.image}
-            isAnchored={true}
-            activeOpacity={0.8}
-            aspectRatio={imageRatio}
-            lockWidth={true}
-            setAspectRatio={_setAspectRatio}
+          <ExpoImage
+            source={{ uri: images.image }}
+            style={[
+              styles.thumbnail,
+              {
+                width: imgWidth,
+                height: Math.min(calcImgHeight, dim.height),
+              },
+            ]}
+            contentFit={resizeMode}
+            onLoad={(evt) => {
+              if (!imageRatio) {
+                const _imgRatio = evt.source.width / evt.source.height;
+                const height = imgWidth / _imgRatio;
+                setCalcImgHeight(height);
+                setImageRatio(content.author + content.permlink, _imgRatio);
+              }
+            }}
           />
         )}
 

--- a/src/components/postCard/children/postCardContent.tsx
+++ b/src/components/postCard/children/postCardContent.tsx
@@ -1,7 +1,6 @@
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 import { TouchableOpacity, Text, View, useWindowDimensions } from 'react-native';
 // Utils
-import { Image as ExpoImage } from 'expo-image';
 import { useIntl } from 'react-intl';
 
 // Components
@@ -11,7 +10,7 @@ import styles from './postCardStyles';
 import { PostCardActionIds } from '../container/postCard';
 import ROUTES from '../../../constants/routeNames';
 import { ContentType } from '../../../providers/hive/hive.types';
-import { AutoHeightImage } from '../../../components/autoHeightImage/autoHeightImage';
+import { AutoHeightImage } from '../../autoHeightImage/autoHeightImage';
 
 const DEFAULT_IMAGE =
   'https://images.ecency.com/DQmT8R33geccEjJfzZEdsRHpP3VE8pu3peRCnQa1qukU4KR/no_image_3x.png';
@@ -65,7 +64,7 @@ export const PostCardContent = ({
 
   const _setAspectRatio = (ratio: number) => {
     setImageRatio(content.author + content.permlink, ratio);
-  }
+  };
 
   let images = { image: DEFAULT_IMAGE, thumbnail: DEFAULT_IMAGE };
   if (content.thumbnail) {


### PR DESCRIPTION
### What does this PR?
- fixes shaky posts appearing on certain android posts
- added image ratio resize animation in post details screen

right now the animated resizing is only supported for blog detail page and not the blog feed, I tried it once but apparently it requires more fine tuning so I had to revert that part for now.

### Issue number
https://github.com/orgs/ecency/projects/4/views/1?pane=issue&itemId=102680937

### Screenshots/Video
BEFORE
https://www.loom.com/share/43bbfc0dc966436d8b9311b567a6ae67

AFTER
https://www.loom.com/share/9d105f4975e04618a73232f78ef8869f
