### PR TITLE
Notification data processing fix

### DIFF
--- a/src/screens/application/hook/useInitApplication.tsx
+++ b/src/screens/application/hook/useInitApplication.tsx
@@ -128,7 +128,7 @@ export const useInitApplication = () => {
 
     // on android messaging event work fine for both background and quite state
     // while notifee events do not fuction as expected
-    if (Platform.OS === 'android') {
+    
       messagingEventRef.current = getMessaging().onNotificationOpenedApp((remoteMessage) => {
         console.log('Notificaiton opened app', remoteMessage);
         _pushNavigate(remoteMessage);
@@ -139,17 +139,19 @@ export const useInitApplication = () => {
         console.log('Initial Notification', initialNotification);
         _pushNavigate(initialNotification);
       }
-    } else if (Platform.OS === 'ios') {
-      // for ios, notifee events work while messaging event are malfunctioning, the foreground event
-      // on ios is called if user opens/starts app from notification
-      notifeeEventRef.current = notifee.onBackgroundEvent(async ({ type, detail }) => {
-        if (type === EventType.PRESS) {
-          console.log('User pressed the notification.', detail.notification);
-          _pushNavigate(detail.notification);
-        }
-      });
+
+      //NOTE: notifee seems to have been malfunctioning, avoid using for testing
+    // } else if (Platform.OS === 'android') {
+    //   // for ios, notifee events work while messaging event are malfunctioning, the foreground event
+    //   // on ios is called if user opens/starts app from notification
+    //   notifee.onBackgroundEvent(async({ type, detail }) => {
+    //     if (type === EventType.PRESS) {
+    //       console.log('User pressed the notification.', detail.notification);
+    //       _pushNavigate(detail.notification);
+    //     }
+    //   });
       
-    }
+    // }
   };
 
   const _handleAppStateChange = (nextAppState) => {

--- a/src/screens/application/hook/useInitApplication.tsx
+++ b/src/screens/application/hook/useInitApplication.tsx
@@ -142,11 +142,13 @@ export const useInitApplication = () => {
     } else if (Platform.OS === 'ios') {
       // for ios, notifee events work while messaging event are malfunctioning, the foreground event
       // on ios is called if user opens/starts app from notification
-      notifeeEventRef.current = notifee.onForegroundEvent(({ type, detail }) => {
+      notifeeEventRef.current = notifee.onBackgroundEvent(async ({ type, detail }) => {
         if (type === EventType.PRESS) {
+          console.log('User pressed the notification.', detail.notification);
           _pushNavigate(detail.notification);
         }
       });
+      
     }
   };
 


### PR DESCRIPTION
### What does this PR?
Bypassing notifee notification reader in favour of updated firebase listeners.

Apparently, based on my testing, there is something wrong with the notification backend, as I was not able to test real notifications by comment on my posts using ecency web logged in with different account.

Eventually the tested I did was in a controlled local environment that mimics the already defined notification data send via local node service running firebase-admin, for ios I created an apn for the notification data for testing.

### Issue number
https://discord.com/channels/@me/920267778190086205/1353596025738362922

### Screenshots/Video
iOS (1. Quit State, 2. Background State, 3. Foreground State)
https://www.loom.com/share/2e1d3f3732f543f0a0811d873acf749f

Android (1. Background State, 2. Quit State, 3. Foreground State)
https://www.loom.com/share/264c11dbae3547c4bfa91fb0bf2d2fde