### PR TITLE
Nt/replacing iphone x package

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "react-native-iap": "^12.16.2",
     "react-native-image-crop-picker": "^0.42.0",
     "react-native-image-viewing": "^0.2.2",
-    "react-native-iphone-x-helper": "Norcy/react-native-iphone-x-helper",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-level-fs": "^3.0.0",
     "react-native-linear-gradient": "^2.8.3",

--- a/src/components/actionModal/view/actionModalStyles.ts
+++ b/src/components/actionModal/view/actionModalStyles.ts
@@ -1,6 +1,5 @@
-import { TextStyle, ViewStyle, ImageStyle, Platform } from 'react-native';
+import { TextStyle, ViewStyle, ImageStyle } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
-import { getBottomSpace } from 'react-native-iphone-x-helper';
 
 export default EStyleSheet.create({
   modalStyle: {
@@ -75,10 +74,6 @@ export default EStyleSheet.create({
     flexWrap: 'wrap-reverse',
     justifyContent: 'space-around',
     alignItems: 'center',
-    marginBottom: Platform.select({
-      ios: getBottomSpace(),
-      android: 12,
-    }),
   } as ViewStyle,
   cancel: {
     backgroundColor: 'transparent',

--- a/src/components/actionModal/view/actionModalView.tsx
+++ b/src/components/actionModal/view/actionModalView.tsx
@@ -7,6 +7,7 @@ import styles from './actionModalStyles';
 
 import { ActionModalData, ButtonTypes } from '../container/actionModalContainer';
 import { MainButton } from '../../mainButton';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export interface ActionModalRef {
   showModal: () => void;
@@ -22,6 +23,7 @@ const ActionModalView = ({ onClose, data }: ActionModalViewProps, ref) => {
   const sheetModalRef = useRef<ActionSheet>();
 
   const intl = useIntl();
+  const insets = useSafeAreaInsets()
 
   useImperativeHandle(ref, () => ({
     showModal: () => {
@@ -38,6 +40,8 @@ const ActionModalView = ({ onClose, data }: ActionModalViewProps, ref) => {
   }
 
   const { title, body, buttons, headerImage, para, headerContent, bodyContent } = data;
+
+  const _actionPanelStyle = {...styles.actionPanel, marginBottom: !insets.bottom && 12};
 
   const _renderContent = (
     <View style={styles.container}>
@@ -57,7 +61,7 @@ const ActionModalView = ({ onClose, data }: ActionModalViewProps, ref) => {
         )}
       </View>
 
-      <View style={styles.actionPanel}>
+      <View style={_actionPanelStyle}>
         {buttons ? (
           buttons.map((props) => (
             <MainButton

--- a/src/components/basicUIElements/view/noInternetConnection/noInternetConnectionView.js
+++ b/src/components/basicUIElements/view/noInternetConnection/noInternetConnectionView.js
@@ -1,22 +1,28 @@
 import React from 'react';
 import { injectIntl } from 'react-intl';
-import { Text, SafeAreaView, View } from 'react-native';
+import { Text, View } from 'react-native';
 
 import { Icon } from '../../../icon';
 
 import styles from './noInternetConnectionStyle';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
-const NoInternetConnection = ({ intl }) => (
-  <SafeAreaView style={styles.grayBackground}>
-    <View style={styles.container}>
-      <Icon style={styles.icon} iconType="MaterialIcons" name="info" size={16} />
-      <Text style={styles.text}>
-        {intl.formatMessage({
-          id: 'alert.no_internet',
-        })}
-      </Text>
-    </View>
-  </SafeAreaView>
-);
+const NoInternetConnection = ({ intl }) => {
+
+  const insets = useSafeAreaInsets();
+
+  return (
+    <SafeAreaView style={{ ...styles.grayBackground, marginTop: -insets.bottom }} edges={['bottom']} >
+      <View style={styles.container}>
+        <Icon style={styles.icon} iconType="MaterialIcons" name="info" size={16} />
+        <Text style={styles.text}>
+          {intl.formatMessage({
+            id: 'alert.no_internet',
+          })}
+        </Text>
+      </View>
+    </SafeAreaView>
+  )
+};
 
 export default injectIntl(NoInternetConnection);

--- a/src/components/beneficiarySelectionContent/styles.ts
+++ b/src/components/beneficiarySelectionContent/styles.ts
@@ -1,5 +1,4 @@
 import EStyleSheet from 'react-native-extended-stylesheet';
-import { getBottomSpace } from 'react-native-iphone-x-helper';
 
 export default EStyleSheet.create({
   sheetContent: {
@@ -28,9 +27,6 @@ export default EStyleSheet.create({
     fontWeight: 'bold',
     flexGrow: 1,
     textAlign: 'left',
-  },
-  listContainer: {
-    paddingBottom: getBottomSpace() + 16,
   },
   container: {
     paddingVertical: 16,

--- a/src/components/bottomTabBar/view/bottomTabBarView.tsx
+++ b/src/components/bottomTabBar/view/bottomTabBarView.tsx
@@ -1,15 +1,12 @@
 import React, { useEffect } from 'react';
 import { View, TouchableOpacity } from 'react-native';
 
-// Components
-// import TabBar from './tabbar';
 
 // Constants
 import { useDispatch } from 'react-redux';
 import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { useIntl } from 'react-intl';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { isIphoneX } from 'react-native-iphone-x-helper';
 import ROUTES from '../../../constants/routeNames';
 
 // Styles
@@ -93,7 +90,7 @@ const BottomTabBarView = ({
     );
   });
 
-  const _bottomPadding = insets.bottom + (isIphoneX() ? 0 : 12);
+  const _bottomPadding = insets.bottom || 16
 
   return <View style={{ ...styles.wrapper, paddingBottom: _bottomPadding }}>{_tabButtons}</View>;
 };

--- a/src/components/foregroundNotification/foregroundNotification.tsx
+++ b/src/components/foregroundNotification/foregroundNotification.tsx
@@ -10,6 +10,7 @@ import ROUTES from '../../constants/routeNames';
 // Styles
 import styles from './styles';
 import RootNavigation from '../../navigation/rootNavigation';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 interface RemoteMessage {
   data: {
@@ -33,16 +34,18 @@ interface Props {
 
 const ForegroundNotification = ({ remoteMessage }: Props) => {
   const intl = useIntl();
+  const insets = useSafeAreaInsets();
   const hideTimeoutRef = useRef<any>(null);
 
-  const [duration] = useState(5000);
+  const [duration] = useState(5000000);
   const [activeId, setActiveId] = useState('');
   const [isVisible, setIsVisible] = useState(false);
-  const [username, setUsername] = useState('');
-  const [title, setTitle] = useState('');
-  const [body, setBody] = useState('');
+  const [username, setUsername] = useState('Test User');
+  const [title, setTitle] = useState('Test title here');
+  const [body, setBody] = useState('now here goes test body to');
 
   useEffect(() => {
+    show();
     if (remoteMessage) {
       const { source, target, type, id } = remoteMessage.data;
       if (activeId !== id && (type === 'reply' || type === 'mention')) {
@@ -105,10 +108,12 @@ const ForegroundNotification = ({ remoteMessage }: Props) => {
     hide();
   };
 
+  const _containerStyle = {...styles.container, marginTop: insets.top};
+
   return (
     isVisible && (
       <Animated.View
-        style={styles.container}
+        style={_containerStyle}
         entering={SlideInUp.duration(500)}
         exiting={FadeOutUp}
       >

--- a/src/components/foregroundNotification/foregroundNotification.tsx
+++ b/src/components/foregroundNotification/foregroundNotification.tsx
@@ -40,12 +40,11 @@ const ForegroundNotification = ({ remoteMessage }: Props) => {
   const [duration] = useState(5000000);
   const [activeId, setActiveId] = useState('');
   const [isVisible, setIsVisible] = useState(false);
-  const [username, setUsername] = useState('Test User');
-  const [title, setTitle] = useState('Test title here');
-  const [body, setBody] = useState('now here goes test body to');
+  const [username, setUsername] = useState('');
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
 
   useEffect(() => {
-    show();
     if (remoteMessage) {
       const { source, target, type, id } = remoteMessage.data;
       if (activeId !== id && (type === 'reply' || type === 'mention')) {

--- a/src/components/foregroundNotification/styles.ts
+++ b/src/components/foregroundNotification/styles.ts
@@ -1,8 +1,5 @@
-import { Platform } from 'react-native';
-import EStyleSheet from 'react-native-extended-stylesheet';
-import { getStatusBarHeight } from 'react-native-iphone-x-helper';
 
-export const CONTAINER_HEIGHT = getStatusBarHeight() + 100;
+import EStyleSheet from 'react-native-extended-stylesheet';
 
 export default EStyleSheet.create({
   container: {
@@ -12,10 +9,6 @@ export default EStyleSheet.create({
     zIndex: 9999,
     marginHorizontal: 8,
     paddingTop: 16,
-    marginTop: Platform.select({
-      ios: getStatusBarHeight() + 12,
-      android: 8,
-    }),
     backgroundColor: '$darkGrayBackground',
     shadowColor: '#5f5f5fbf',
     shadowOpacity: 0.3,

--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -6,7 +6,6 @@ import {
   GestureStateChangeEvent,
   PanGestureHandlerEventPayload,
 } from 'react-native-gesture-handler';
-import { getBottomSpace } from 'react-native-iphone-x-helper';
 import Animated, {
   Easing,
   clamp,
@@ -23,6 +22,7 @@ import styles from '../styles/editorToolbarStyles';
 import ROUTES from '../../../constants/routeNames';
 import { DEFAULT_USER_DRAFT_ID } from '../../../redux/constants/constants';
 import { TextFormatModal } from './textFormatModal';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type Props = {
   draftId?: string;
@@ -54,6 +54,7 @@ export const EditorToolbar = ({
   handleShowSnippets,
 }: Props) => {
   const navigation = useNavigation();
+  const insets = useSafeAreaInsets();
 
   const currentAccount = useAppSelector((state) => state.account.currentAccount);
   const pollDraft = useAppSelector(
@@ -252,7 +253,7 @@ export const EditorToolbar = ({
   const _buttonsContainerStyle: ViewStyle = {
     ...styles.buttonsContainer,
     borderTopWidth: isExtensionVisible ? 1 : 0,
-    paddingBottom: !isKeyboardVisible ? getBottomSpace() : 0,
+    paddingBottom: !isKeyboardVisible ? insets.bottom : 0,
   };
 
   return (

--- a/src/components/markdownEditor/styles/editorToolbarStyles.ts
+++ b/src/components/markdownEditor/styles/editorToolbarStyles.ts
@@ -1,6 +1,5 @@
 import { Platform, ViewStyle } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
-import { getBottomSpace } from 'react-native-iphone-x-helper';
 
 const _dropShadow = {
   shadowOpacity: 0.1,
@@ -36,7 +35,6 @@ export default EStyleSheet.create({
     width: '100%',
     backgroundColor: '$primaryBackgroundColor',
     borderColor: '$primaryLightBackground',
-    paddingBottom: getBottomSpace(),
   },
   iconBottomBar: {
     borderBottomWidth: 3,

--- a/src/components/modal/view/modalView.tsx
+++ b/src/components/modal/view/modalView.tsx
@@ -46,7 +46,7 @@ export default class Modal extends PureComponent {
       children,
       isRadius,
       isTransparent = false,
-      animationType = 'fade',
+      animationType = 'slide',
       isBottomModal = false,
     } = this.props;
     return (
@@ -58,6 +58,7 @@ export default class Modal extends PureComponent {
         onShow={() => this._handleOnOpen(this)}
         onModalHide={() => console.log('hide')}
         onModalDismiss={() => console.log('dismiss')}
+        presentationStyle='formSheet'
         {...this.props}
       >
         <SafeAreaView

--- a/src/components/organisms/quickProfileModal/children/quickProfileContent.tsx
+++ b/src/components/organisms/quickProfileModal/children/quickProfileContent.tsx
@@ -16,6 +16,7 @@ import { useAppDispatch, useAppSelector } from '../../../../hooks';
 import { toastNotification } from '../../../../redux/actions/uiAction';
 import bugsnapInstance from '../../../../config/bugsnag';
 import RootNavigation from '../../../../navigation/rootNavigation';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 interface QuickProfileContentProps {
   username: string;
@@ -24,6 +25,7 @@ interface QuickProfileContentProps {
 
 export const QuickProfileContent = ({ username, onClose }: QuickProfileContentProps) => {
   const intl = useIntl();
+  const insets = useSafeAreaInsets();
   const dispatch = useAppDispatch();
 
   const currentAccount = useAppSelector((state) => state.account.currentAccount);
@@ -220,8 +222,15 @@ export const QuickProfileContent = ({ username, onClose }: QuickProfileContentPr
     { label: intl.formatMessage({ id: 'profile.reputation' }), value: _reputation },
   ] as StatsItem[];
 
+
+  const _modaStyle = {
+    ...styles.modalStyle,
+    marginBottom: !insets.bottom && 16,
+  }
+
+
   return (
-    <View style={styles.modalStyle}>
+    <View style={_modaStyle}>
       <ProfileBasic
         username={username}
         about={_about}

--- a/src/components/sideMenu/view/sideMenuStyles.js
+++ b/src/components/sideMenu/view/sideMenuStyles.js
@@ -1,5 +1,4 @@
 import EStyleSheet from 'react-native-extended-stylesheet';
-import { getBottomSpace } from 'react-native-iphone-x-helper';
 import { isRTL } from '../../../utils/I18nUtils';
 
 export default EStyleSheet.create({
@@ -7,7 +6,6 @@ export default EStyleSheet.create({
     flex: 1,
     flexDirection: 'column',
     backgroundColor: '$primaryBackgroundColor',
-    paddingBottom: getBottomSpace(),
   },
   headerView: {
     flexDirection: 'row',

--- a/src/components/sideMenu/view/sideMenuView.js
+++ b/src/components/sideMenu/view/sideMenuView.js
@@ -5,7 +5,7 @@ import LinearGradient from 'react-native-linear-gradient';
 import VersionNumber from 'react-native-version-number';
 import { isEmpty } from 'lodash';
 import { useDispatch } from 'react-redux';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { getStorageType } from '../../../realm/realm';
 
@@ -216,13 +216,13 @@ const SideMenuView = ({
   };
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView edges={['bottom']} style={styles.container}>
       {_renderHeader()}
       <View style={styles.contentView}>
         <FlatList data={menuItems} keyExtractor={(item) => item.id} renderItem={_renderItem} />
       </View>
       <Text style={styles.versionText}>{`v${appVersion}, ${buildVersion}${storageT}`}</Text>
-    </View>
+    </SafeAreaView>
   );
 };
 

--- a/src/screens/application/children/applicationScreen.tsx
+++ b/src/screens/application/children/applicationScreen.tsx
@@ -115,9 +115,8 @@ const ApplicationScreen = ({ foregroundNotificationData }) => {
   const _renderAppNavigator = () => {
     return (
       <Fragment>
-        {!isConnected && <NoInternetConnection />}
-
         <AppNavigator />
+        {!isConnected && <NoInternetConnection />}
       </Fragment>
     );
   };

--- a/src/screens/drafts/screen/draftStyles.js
+++ b/src/screens/drafts/screen/draftStyles.js
@@ -1,6 +1,4 @@
-import { Platform, StatusBar } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
-import { getStatusBarHeight } from 'react-native-iphone-x-helper';
 
 export default EStyleSheet.create({
   tabbar: {
@@ -19,7 +17,7 @@ export default EStyleSheet.create({
   deleteButtonContainer: {
     position: 'absolute',
     right: 0,
-    top: Platform.select({ ios: getStatusBarHeight() + 4, android: StatusBar.currentHeight + 4 }),
+    top: 8,
     justifyContent: 'center',
   },
 

--- a/src/screens/drafts/screen/draftsScreen.js
+++ b/src/screens/drafts/screen/draftsScreen.js
@@ -185,12 +185,14 @@ const DraftsScreen = ({
 
   const _renderDeleteButton = () => {
     return (
-      <>
-        <AnimatedView.View
-          entering={SlideInRight}
-          exiting={SlideOutRight}
-          style={styles.deleteButtonContainer}
-        >
+
+
+      <AnimatedView.View
+        entering={SlideInRight}
+        exiting={SlideOutRight}
+        style={styles.deleteButtonContainer}
+      >
+        <SafeAreaView>
           <IconButton
             style={styles.deleteButton}
             color={EStyleSheet.value('$pureWhite')}
@@ -201,8 +203,9 @@ const DraftsScreen = ({
             onPress={() => actionSheet?.current?.show()}
             isLoading={isBatchDeleting}
           />
-        </AnimatedView.View>
-      </>
+        </SafeAreaView>
+      </AnimatedView.View >
+
     );
   };
 

--- a/src/screens/steem-connect/hiveSigner.js
+++ b/src/screens/steem-connect/hiveSigner.js
@@ -107,7 +107,6 @@ class HiveSigner extends PureComponent {
   render() {
     return (
       <View style={{ flex: 1 }}>
-        <StatusBar hidden translucent />
         <WebView
           source={{
             uri: `${hsOptions.base_url}oauth2/authorize?client_id=${

--- a/yarn.lock
+++ b/yarn.lock
@@ -11561,10 +11561,6 @@ react-native-image-viewing@^0.2.2:
   resolved "https://registry.yarnpkg.com/react-native-image-viewing/-/react-native-image-viewing-0.2.2.tgz#fb26e57d7d3d9ce4559a3af3d244387c0367242b"
   integrity sha512-osWieG+p/d2NPbAyonOMubttajtYEYiRGQaJA54slFxZ69j1V4/dCmcrVQry47ktVKy8/qpFwCpW1eT6MH5T2Q==
 
-react-native-iphone-x-helper@Norcy/react-native-iphone-x-helper:
-  version "2.0.0"
-  resolved "https://codeload.github.com/Norcy/react-native-iphone-x-helper/tar.gz/aff3730b2614947a72bcdd86e35ba0217ca1054c"
-
 react-native-iphone-x-helper@^1.0.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"


### PR DESCRIPTION
### What does this PR?
apparently iphone x helper package was causing a lot ui related spacing issues, considering it was even last updated four years ago, it is only sensible to replace it with updated safe-area-context methods.

An extra change for No Connection popup is, I had to position it at the bottom, refining ui while keep it up top was becoming tricky, it's possible but it seems too much effort considering it's application is very minor. let me know it important to keep it up top.

### Issue number
https://github.com/orgs/ecency/projects/4/views/1?pane=issue&itemId=106720803
https://github.com/orgs/ecency/projects/4/views/1?pane=issue&itemId=97602273

### Screenshots/Video
![Screenshot 2025-04-17 at 17 54 48](https://github.com/user-attachments/assets/38b2e508-aa42-4d89-a888-f2c6621fa587)
![Screenshot 2025-04-17 at 17 56 07](https://github.com/user-attachments/assets/f2810bc7-2afa-4334-984d-e075e4d51a75)
![Screenshot 2025-04-17 at 17 57 57](https://github.com/user-attachments/assets/9fa4c770-737c-472a-838e-ee2f5b564811)
![Screenshot 2025-04-17 at 17 59 21](https://github.com/user-attachments/assets/725807a1-6f73-40db-9292-84160c69b3c0)
![Screenshot 2025-04-17 at 18 00 01](https://github.com/user-attachments/assets/cb3d62f0-bc3a-44b7-becd-2846f9333789)
![Screenshot 2025-04-17 at 18 03 23](https://github.com/user-attachments/assets/97c4d4e6-97c2-43b5-b197-fe1ea21cf3a9)
![Screenshot 2025-04-17 at 18 35 29](https://github.com/user-attachments/assets/9944ecd7-047f-48af-b1e7-939f4152682a)

