### PR TITLE
fix ui glitch in asset card

### DIFF
--- a/src/screens/wallet/styles/children.styles.ts
+++ b/src/screens/wallet/styles/children.styles.ts
@@ -22,11 +22,11 @@ export default EStyleSheet.create({
   } as ViewStyle,
 
   cardTitleContainer: {
+    flex: 1,
     marginHorizontal: 8,
   } as ViewStyle,
 
   cardValuesContainer: {
-    flex: 1,
     marginHorizontal: 8,
     justifyContent: 'flex-end',
   } as ViewStyle,


### PR DESCRIPTION
### What does this PR?
if asset name is too long, the asset amounts gets pushed to corner disturbing the ui. This PR fixes that glitch


### Issue number
https://github.com/orgs/ecency/projects/4/views/1?pane=issue&itemId=99867325

### Screenshots/Video
**BEFORE**
![Screenshot 2025-04-22 at 11 02 36](https://github.com/user-attachments/assets/77b1ddde-b95f-4435-bf76-90566989dcfd)

**AFTER**
![Screenshot 2025-04-22 at 11 00 59](https://github.com/user-attachments/assets/a8ea8280-0340-45e1-ab3a-a026d2d0657d)
