### PR TITLE
shaky waves fix

### DIFF
--- a/src/components/autoHeightImage/autoHeightImage.tsx
+++ b/src/components/autoHeightImage/autoHeightImage.tsx
@@ -90,6 +90,11 @@ export const AutoHeightImage = ({
       : Math.round(width < contentWidth ? width : contentWidth);
     const newHeight = Math.round((height / width) * newWidth);
 
+    // if newHeight and oldHeight are approximately equal, skip animation
+    if (Math.abs(newHeight - imgHeightAnim.value) < 1) {
+      return;
+    }
+
     if (!aspectRatio) {
       animateHeight(newHeight); // Animate the height change
     }


### PR DESCRIPTION
### What does this PR?
apparently there was another loophole causing image render on certain waves.
this pr attempts to fix the issue by skipping image resize if height change is minimal between renders.


### Screenshots/Video
**BEFORE (shaky waves)**
https://github.com/user-attachments/assets/ad9504cc-7321-4218-9f32-60356c008c45


**AFTER (stables waves)**
https://github.com/user-attachments/assets/d6766331-2010-4d01-a750-f9340929ca04

