### PR TITLE
Nt/wave previews

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -112,6 +112,7 @@ import OrDivider from './orDivider/orDividerView';
 import PostTranslationModal from './post-translation-modal/postTranslationModal';
 import { ImageViewer } from './imageViewer';
 import { WalkthroughMarker } from './walkthroughMarker';
+import { PostCardMini } from './postCardMini';
 
 // Basic UI Elements
 import {
@@ -276,4 +277,5 @@ export {
   WalkthroughMarker,
   ProposalVoteRequest,
   HiveAuthModal,
+  PostCardMini
 };

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -277,5 +277,5 @@ export {
   WalkthroughMarker,
   ProposalVoteRequest,
   HiveAuthModal,
-  PostCardMini
+  PostCardMini,
 };

--- a/src/components/postCardMini/container/postCardMini.tsx
+++ b/src/components/postCardMini/container/postCardMini.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
-import styles from '../styles/postCardMini.styles';
-import { useGetPostQuery } from '../../../providers/queries/postQueries/postQueries';
 import Placeholder from 'rn-placeholder';
 import EStyleSheet from 'react-native-extended-stylesheet';
 import { Image as ExpoImage } from 'expo-image';
-
+import { useGetPostQuery } from '../../../providers/queries/postQueries/postQueries';
+import styles from '../styles/postCardMini.styles';
 
 interface PostCardMiniProps {
   author: string;
@@ -15,24 +14,39 @@ interface PostCardMiniProps {
 }
 
 export const PostCardMini = ({ author, permlink, contentWidth, onPress }: PostCardMiniProps) => {
-
-  const _containerStyle = { ...styles.container, width: contentWidth }
+  const _containerStyle = { ...styles.container, width: contentWidth };
 
   const getPostQuery = useGetPostQuery({ author, permlink });
 
-  const _renderPlaceholder = <Placeholder.Box color={EStyleSheet.value('$primaryLightBackground')} animate="fade" height={12} width={contentWidth - 92} />
+  const _renderPlaceholder = (
+    <Placeholder.Box
+      color={EStyleSheet.value('$primaryLightBackground')}
+      animate="fade"
+      height={12}
+      width={contentWidth - 92}
+    />
+  );
 
   return (
     <TouchableOpacity onPress={onPress} style={_containerStyle}>
       <ExpoImage source={{ uri: getPostQuery.data?.image }} style={styles.thumbnail} />
       <View style={styles.textContainer}>
         <Text style={styles.hivePost}>HIVE POST</Text>
-        {getPostQuery.isLoading
-          ? _renderPlaceholder : <Text style={styles.title} numberOfLines={1}>{getPostQuery.data.title}</Text>}
-        {getPostQuery.isLoading
-          ? _renderPlaceholder : <Text style={styles.body} numberOfLines={1}>{getPostQuery.data.summary}</Text>}
+        {getPostQuery.isLoading ? (
+          _renderPlaceholder
+        ) : (
+          <Text style={styles.title} numberOfLines={1}>
+            {getPostQuery.data.title}
+          </Text>
+        )}
+        {getPostQuery.isLoading ? (
+          _renderPlaceholder
+        ) : (
+          <Text style={styles.body} numberOfLines={1}>
+            {getPostQuery.data.summary}
+          </Text>
+        )}
       </View>
     </TouchableOpacity>
   );
 };
-

--- a/src/components/postCardMini/container/postCardMini.tsx
+++ b/src/components/postCardMini/container/postCardMini.tsx
@@ -1,19 +1,38 @@
 import React from 'react';
-import { View, Text, Image } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import styles from '../styles/postCardMini.styles';
+import { useGetPostQuery } from '../../../providers/queries/postQueries/postQueries';
+import Placeholder from 'rn-placeholder';
+import EStyleSheet from 'react-native-extended-stylesheet';
+import { Image as ExpoImage } from 'expo-image';
 
 
+interface PostCardMiniProps {
+  author: string;
+  permlink: string;
+  contentWidth: number;
+  onPress: () => void;
+}
 
-export const PostCardMini = ({ thumbnailUrl, title, body }) => {
+export const PostCardMini = ({ author, permlink, contentWidth, onPress }: PostCardMiniProps) => {
+
+  const _containerStyle = { ...styles.container, width: contentWidth }
+
+  const getPostQuery = useGetPostQuery({ author, permlink });
+
+  const _renderPlaceholder = <Placeholder.Box color={EStyleSheet.value('$primaryLightBackground')} animate="fade" height={12} width={contentWidth - 92} />
+
   return (
-    <View style={styles.container}>
-      <Image source={{ uri: thumbnailUrl }} style={styles.thumbnail} />
+    <TouchableOpacity onPress={onPress} style={_containerStyle}>
+      <ExpoImage source={{ uri: getPostQuery.data?.image }} style={styles.thumbnail} />
       <View style={styles.textContainer}>
         <Text style={styles.hivePost}>HIVE POST</Text>
-        <Text style={styles.title} numberOfLines={1}>{title}</Text>
-        <Text style={styles.body} numberOfLines={1}>{body}</Text>
+        {getPostQuery.isLoading
+          ? _renderPlaceholder : <Text style={styles.title} numberOfLines={1}>{getPostQuery.data.title}</Text>}
+        {getPostQuery.isLoading
+          ? _renderPlaceholder : <Text style={styles.body} numberOfLines={1}>{getPostQuery.data.summary}</Text>}
       </View>
-    </View>
+    </TouchableOpacity>
   );
 };
 

--- a/src/components/postCardMini/container/postCardMini.tsx
+++ b/src/components/postCardMini/container/postCardMini.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Text, Image } from 'react-native';
+import styles from '../styles/postCardMini.styles';
+
+
+
+export const PostCardMini = ({ thumbnailUrl, title, body }) => {
+  return (
+    <View style={styles.container}>
+      <Image source={{ uri: thumbnailUrl }} style={styles.thumbnail} />
+      <View style={styles.textContainer}>
+        <Text style={styles.hivePost}>HIVE POST</Text>
+        <Text style={styles.title} numberOfLines={1}>{title}</Text>
+        <Text style={styles.body} numberOfLines={1}>{body}</Text>
+      </View>
+    </View>
+  );
+};
+

--- a/src/components/postCardMini/index.ts
+++ b/src/components/postCardMini/index.ts
@@ -1,1 +1,1 @@
-export * from './container/postCardMini'
+export * from './container/postCardMini';

--- a/src/components/postCardMini/index.ts
+++ b/src/components/postCardMini/index.ts
@@ -1,0 +1,1 @@
+export * from './container/postCardMini'

--- a/src/components/postCardMini/styles/postCardMini.styles.ts
+++ b/src/components/postCardMini/styles/postCardMini.styles.ts
@@ -1,0 +1,41 @@
+import { ViewStyle } from "react-native";
+import EStyleSheet from "react-native-extended-stylesheet";
+
+
+export default EStyleSheet.create({
+    container: {
+        flexDirection: 'row',
+        padding: 8,
+        borderWidth: EStyleSheet.hairlineWidth,
+        borderColor: '$iconColor',
+        borderRadius: 12,
+        marginRight: 8,
+        marginBottom: 12,
+    } as ViewStyle,
+    thumbnail: {
+        width: 56,
+        height: 56,
+        borderRadius: 12,
+        marginRight: 12,
+        backgroundColor: '$primaryLightBackground',
+    },
+    textContainer: {
+        flex: 1,
+        justifyContent: 'space-between',
+        marginVertical: 4,
+    },
+    hivePost: {
+        fontWeight: '300',
+        fontSize: 10,
+        color: '$primaryBlack',
+    },
+    title: {
+        fontWeight: '500',
+        fontSize: 14,
+        color: '$primaryBlue',
+    },
+    body: {
+        fontSize: 12,
+        color: '$iconColor',
+    },
+});

--- a/src/components/postCardMini/styles/postCardMini.styles.ts
+++ b/src/components/postCardMini/styles/postCardMini.styles.ts
@@ -9,8 +9,6 @@ export default EStyleSheet.create({
         borderWidth: EStyleSheet.hairlineWidth,
         borderColor: '$iconColor',
         borderRadius: 12,
-        marginRight: 8,
-        marginBottom: 12,
     } as ViewStyle,
     thumbnail: {
         width: 56,

--- a/src/components/postCardMini/styles/postCardMini.styles.ts
+++ b/src/components/postCardMini/styles/postCardMini.styles.ts
@@ -1,39 +1,38 @@
-import { ViewStyle } from "react-native";
-import EStyleSheet from "react-native-extended-stylesheet";
-
+import { ViewStyle } from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet';
 
 export default EStyleSheet.create({
-    container: {
-        flexDirection: 'row',
-        padding: 8,
-        borderWidth: EStyleSheet.hairlineWidth,
-        borderColor: '$iconColor',
-        borderRadius: 12,
-    } as ViewStyle,
-    thumbnail: {
-        width: 56,
-        height: 56,
-        borderRadius: 12,
-        marginRight: 12,
-        backgroundColor: '$primaryLightBackground',
-    },
-    textContainer: {
-        flex: 1,
-        justifyContent: 'space-between',
-        marginVertical: 4,
-    },
-    hivePost: {
-        fontWeight: '300',
-        fontSize: 10,
-        color: '$primaryBlack',
-    },
-    title: {
-        fontWeight: '500',
-        fontSize: 14,
-        color: '$primaryBlue',
-    },
-    body: {
-        fontSize: 12,
-        color: '$iconColor',
-    },
+  container: {
+    flexDirection: 'row',
+    padding: 8,
+    borderWidth: EStyleSheet.hairlineWidth,
+    borderColor: '$iconColor',
+    borderRadius: 12,
+  } as ViewStyle,
+  thumbnail: {
+    width: 56,
+    height: 56,
+    borderRadius: 12,
+    marginRight: 12,
+    backgroundColor: '$primaryLightBackground',
+  },
+  textContainer: {
+    flex: 1,
+    justifyContent: 'space-between',
+    marginVertical: 4,
+  },
+  hivePost: {
+    fontWeight: '300',
+    fontSize: 10,
+    color: '$primaryBlack',
+  },
+  title: {
+    fontWeight: '500',
+    fontSize: 14,
+    color: '$primaryBlue',
+  },
+  body: {
+    fontSize: 12,
+    color: '$iconColor',
+  },
 });

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -3,14 +3,12 @@ import RenderHTML, { CustomRendererProps, Element, TNode } from 'react-native-re
 import { useHtmlIframeProps, iframeModel } from '@native-html/iframe-plugin';
 import WebView from 'react-native-webview';
 import { ScrollView } from 'react-native-gesture-handler';
-// import { prependChild, removeElement } from 'htmlparser2/node_modules/domutils';
+import { Text, TouchableOpacity } from 'react-native';
 import styles from './postHtmlRendererStyles';
 import { LinkData, parseLinkData } from './linkDataParser';
 import VideoThumb from './videoThumb';
 import { AutoHeightImage } from '../autoHeightImage/autoHeightImage';
 import { PostCardMini, UserAvatar, VideoPlayer } from '..';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import EStyleSheet from 'react-native-extended-stylesheet';
 
 interface PostHtmlRendererProps {
   contentWidth: number;
@@ -128,7 +126,7 @@ export const PostHtmlRenderer = memo(
           default:
             break;
         }
-      } catch (error) { }
+      } catch (error) {}
     };
 
     // this method checks if image is a child of table column
@@ -241,38 +239,40 @@ export const PostHtmlRenderer = memo(
         );
       }
 
-
-      if(tnode.classes?.indexOf('markdown-post-link') >= 0) {
-        return <PostCardMini author={parsedTnode.author} permlink={parsedTnode.permlink} onPress={_onPress} contentWidth={contentWidth} />
+      if (tnode.classes?.indexOf('markdown-post-link') >= 0) {
+        return (
+          <PostCardMini
+            author={parsedTnode.author}
+            permlink={parsedTnode.permlink}
+            onPress={_onPress}
+            contentWidth={contentWidth}
+          />
+        );
       }
 
-
-      //render user avatar
+      // render user avatar
       if (tnode.classes?.indexOf('markdown-author-link') >= 0) {
-
-        const usernameStyle = { ...styles.tagText, marginLeft: 4 }
+        const usernameStyle = { ...styles.tagText, marginLeft: 4 };
         return (
           <TouchableOpacity onPress={_onPress} style={styles.tagWrapper}>
-
             <UserAvatar
               username={parsedTnode.author || ''}
-              size='small'
+              size="small"
               metadata={metadata}
               noAction
             />
-            <Text style={usernameStyle} >@{tnode.attributes['data-author']}</Text>
-
+            <Text style={usernameStyle}>@{tnode.attributes['data-author']}</Text>
           </TouchableOpacity>
-        )
+        );
       }
 
-      //render tag
+      // render tag
       if (tnode.classes?.indexOf('markdown-tag-link') >= 0) {
         return (
           <TouchableOpacity onPress={_onPress} style={styles.tagWrapper}>
-            <Text style={styles.tagText} >#{parsedTnode.tag}</Text>
+            <Text style={styles.tagText}>#{parsedTnode.tag}</Text>
           </TouchableOpacity>
-        )
+        );
       }
 
       return <InternalRenderer tnode={tnode} onPress={_onPress} {...props} />;

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -8,7 +8,7 @@ import styles from './postHtmlRendererStyles';
 import { LinkData, parseLinkData } from './linkDataParser';
 import VideoThumb from './videoThumb';
 import { AutoHeightImage } from '../autoHeightImage/autoHeightImage';
-import { UserAvatar, VideoPlayer } from '..';
+import { PostCardMini, UserAvatar, VideoPlayer } from '..';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import EStyleSheet from 'react-native-extended-stylesheet';
 
@@ -241,6 +241,12 @@ export const PostHtmlRenderer = memo(
         );
       }
 
+
+      if(tnode.classes?.indexOf('markdown-post-link') >= 0) {
+        return <PostCardMini author={parsedTnode.author} permlink={parsedTnode.permlink} onPress={_onPress} contentWidth={contentWidth} />
+      }
+
+
       //render user avatar
       if (tnode.classes?.indexOf('markdown-author-link') >= 0) {
 
@@ -249,7 +255,7 @@ export const PostHtmlRenderer = memo(
           <TouchableOpacity onPress={_onPress} style={styles.tagWrapper}>
 
             <UserAvatar
-              username={tnode.attributes['data-author']}
+              username={parsedTnode.author || ''}
               size='small'
               metadata={metadata}
               noAction
@@ -264,7 +270,7 @@ export const PostHtmlRenderer = memo(
       if (tnode.classes?.indexOf('markdown-tag-link') >= 0) {
         return (
           <TouchableOpacity onPress={_onPress} style={styles.tagWrapper}>
-            <Text style={styles.tagText} >#{tnode.attributes['data-tag']}</Text>
+            <Text style={styles.tagText} >#{parsedTnode.tag}</Text>
           </TouchableOpacity>
         )
       }

--- a/src/components/postHtmlRenderer/postHtmlRenderer.tsx
+++ b/src/components/postHtmlRenderer/postHtmlRenderer.tsx
@@ -8,7 +8,9 @@ import styles from './postHtmlRendererStyles';
 import { LinkData, parseLinkData } from './linkDataParser';
 import VideoThumb from './videoThumb';
 import { AutoHeightImage } from '../autoHeightImage/autoHeightImage';
-import { VideoPlayer } from '..';
+import { UserAvatar, VideoPlayer } from '..';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import EStyleSheet from 'react-native-extended-stylesheet';
 
 interface PostHtmlRendererProps {
   contentWidth: number;
@@ -126,7 +128,7 @@ export const PostHtmlRenderer = memo(
           default:
             break;
         }
-      } catch (error) {}
+      } catch (error) { }
     };
 
     // this method checks if image is a child of table column
@@ -237,6 +239,34 @@ export const PostHtmlRenderer = memo(
             onPress={_onPress}
           />
         );
+      }
+
+      //render user avatar
+      if (tnode.classes?.indexOf('markdown-author-link') >= 0) {
+
+        const usernameStyle = { ...styles.tagText, marginLeft: 4 }
+        return (
+          <TouchableOpacity onPress={_onPress} style={styles.tagWrapper}>
+
+            <UserAvatar
+              username={tnode.attributes['data-author']}
+              size='small'
+              metadata={metadata}
+              noAction
+            />
+            <Text style={usernameStyle} >@{tnode.attributes['data-author']}</Text>
+
+          </TouchableOpacity>
+        )
+      }
+
+      //render tag
+      if (tnode.classes?.indexOf('markdown-tag-link') >= 0) {
+        return (
+          <TouchableOpacity onPress={_onPress} style={styles.tagWrapper}>
+            <Text style={styles.tagText} >#{tnode.attributes['data-tag']}</Text>
+          </TouchableOpacity>
+        )
       }
 
       return <InternalRenderer tnode={tnode} onPress={_onPress} {...props} />;

--- a/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
+++ b/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
@@ -21,6 +21,7 @@ export default EStyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     flexWrap: 'wrap',
+    textAlignVertical: 'center'
   } as TextStyle,
   h6: {
     fontSize: 14,
@@ -128,4 +129,19 @@ export default EStyleSheet.create({
   imageGalleryHeaderText: {
     color: '$primaryDarkText',
   },
+  tagWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: EStyleSheet.hairlineWidth,
+    borderColor: '$iconColor',
+    paddingVertical: 2,
+    borderRadius: 20,
+    height: 18,
+    marginBottom: -3,
+  },
+  tagText: {
+    color: '$primaryBlue',
+    fontSize: 12,
+    marginHorizontal: 6,
+  }
 });

--- a/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
+++ b/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
@@ -21,7 +21,7 @@ export default EStyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     flexWrap: 'wrap',
-    textAlignVertical: 'center'
+    textAlignVertical: 'center',
   } as TextStyle,
   h6: {
     fontSize: 14,
@@ -143,6 +143,6 @@ export default EStyleSheet.create({
     color: '$primaryBlue',
     fontSize: 12,
     marginHorizontal: 6,
-    marginTop:-2
-  }
+    marginTop: -2,
+  },
 });

--- a/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
+++ b/src/components/postHtmlRenderer/postHtmlRendererStyles.ts
@@ -143,5 +143,6 @@ export default EStyleSheet.create({
     color: '$primaryBlue',
     fontSize: 12,
     marginHorizontal: 6,
+    marginTop:-2
   }
 });

--- a/src/components/userAvatar/view/userAvatarView.tsx
+++ b/src/components/userAvatar/view/userAvatarView.tsx
@@ -68,6 +68,9 @@ const UserAvatarView = ({
     if (size === 'xxl') {
       _size = 128;
     }
+    if(size === 'small') {
+      _size = 18;
+    }
   }
 
   return (

--- a/src/components/userAvatar/view/userAvatarView.tsx
+++ b/src/components/userAvatar/view/userAvatarView.tsx
@@ -68,7 +68,7 @@ const UserAvatarView = ({
     if (size === 'xxl') {
       _size = 128;
     }
-    if(size === 'small') {
+    if (size === 'small') {
       _size = 18;
     }
   }


### PR DESCRIPTION
### What does this PR?
Added user avatar, tag pill and post card preview support for post renderer.
It is not perfect, especially the vertical alignment of user avatar and pill on android (second screenshot). I have been trying to adjust it but apparently it needs react-native level changes to Text component
Also real world performance affects must be assessed for fetching and rendering linked post meta while scrolling waves list.

### Issue number
https://github.com/orgs/ecency/projects/4/views/1?pane=issue&itemId=102392556

### Screenshots/Video
IOS RESULTS
![Screenshot 2025-04-24 at 12 00 43](https://github.com/user-attachments/assets/6a83ef01-654a-4775-b4e6-a1ee57deaccd)

ANDROID RESULTS
![Screenshot 2025-04-24 at 12 06 21](https://github.com/user-attachments/assets/bffa9288-c7bf-4a11-b1e4-bdebb6ce4b08)

WAVES SCREEN
![Screenshot 2025-04-24 at 11 44 13](https://github.com/user-attachments/assets/86a556ee-7517-49fb-acf1-76ccf4402676)
