### PR TITLE
Nt/poll UI fix

### DIFF
--- a/src/components/postPoll/children/pollHeader.tsx
+++ b/src/components/postPoll/children/pollHeader.tsx
@@ -35,7 +35,7 @@ export const PollHeader = ({ metadata, expired, compactView }: PollHeaderProps) 
   return (
     <View>
       <View style={_headerStyle}>
-        <Text style={styles.question}>{metadata.question}</Text>
+        <Text style={styles.question}>{metadata.question?.trim()}</Text>
         <PopoverWrapper text={_endDate.toString()}>
           <View style={styles.timeContainer}>
             <Text style={styles.timeText}>{formattedEndTime}</Text>

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -354,7 +354,7 @@ export const convertToPollMeta = (pollDraft: PollDraft) => {
 
   return {
     content_type: ContentType.POLL,
-    question: pollDraft.title,
+    question: pollDraft.title.trim(),
     choices: pollDraft.choices,
     preferred_interpretation: pollDraft.interpretation,
     end_time: Math.floor(new Date(pollDraft.endTime).getTime() / 1000),


### PR DESCRIPTION
### What does this PR?
something have been causing this dude's poll to have extra white spacing, I asked him if he intentionally does that, apparently he does not. 

I added a post and pre trim of question to keep the UI well formed irrespective

### Issue number
https://github.com/orgs/ecency/projects/4/views/1?pane=issue&itemId=107904011

### Screenshots/Video
**BEFORE**
![Screenshot 2025-04-29 at 12 19 41](https://github.com/user-attachments/assets/e185cc5e-7d21-4d84-a31b-e20f6afdccf1)

**AFTER**
![Screenshot 2025-04-29 at 12 19 49](https://github.com/user-attachments/assets/88a3f9dd-b927-4415-b917-50d2fe26b372)

