### PR TITLE
Nt/in app fix

### DIFF
--- a/src/components/basicUIElements/view/placeHolder/boostPlaceHolderView.js
+++ b/src/components/basicUIElements/view/placeHolder/boostPlaceHolderView.js
@@ -12,7 +12,7 @@ const BoostPlaceHolder = () => {
 
   const ratio = (dim.height - 300) / 50 / 1.3;
   const listElements = [];
-  const isDarkTheme = useSelector((state) => state.application.isDarkTeme);
+  const isDarkTheme = useSelector((state) => state.application.isDarkTheme);
   const color = isDarkTheme ? '#2e3d51' : '#f5f5f5';
   times(parseInt(ratio), (i) => {
     listElements.push(

--- a/src/containers/inAppPurchaseContainer.tsx
+++ b/src/containers/inAppPurchaseContainer.tsx
@@ -63,7 +63,7 @@ class InAppPurchaseContainer extends Component {
         this._purchaseUpdatedListener();
       }
 
-      this._getItems();
+      await this._getItems();
       await this._handleQrPurchase();
 
       // place rest of unconsumed purhcases in state


### PR DESCRIPTION
### What does this PR?
in iOS, latest StoreKit do not allow parallel calls to fetch products or any purchases related call, this was throwing request cancelled issue.

Fixed this by forcing single IAP on purchases initialisation

### Issue number
https://github.com/orgs/ecency/projects/4/views/1?pane=issue&itemId=110190357

### Screenshots/Video
![Screenshot 2025-05-12 at 20 27 02](https://github.com/user-attachments/assets/a5269e68-4a3c-488e-821c-4e39940e56f4)