### PR TITLE
downgrade okhttp to use kotlin 2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,7 @@ buildscript {
         googlePlayServicesVisionVersion = "17.0.2"
         googlePlayServicesVersion = "16.+"
         firebaseVersion = "17.3.4"
+        okhttp = "4.12.0"
     }
     repositories {
         google()


### PR DESCRIPTION
### What does this PR?
Fixed build issue causing android side to fail.

okhttp a dependecy used by rn-fetch-blog was set to use latest okhttp which now uses kotlin 2.2.0, it's not yet supported by RN hence causing the build to fail.

p.s. I knew it must be something small that's causing the build to fail, but this small, insane, took me a good while to identify root out the issue.