### PR TITLE
Nt/keyboad handling below 35

### DIFF
--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -252,9 +252,20 @@ export const EditorToolbar = ({
     );
   };
 
+
   const _containerStyle: ViewStyle = isExtensionVisible
     ? styles.container
     : styles.shadowedContainer;
+
+
+  const _keyboardAdjustedStyle = {
+    ..._containerStyle,
+    marginBottom:
+      Platform.OS === 'android' && Platform.Version < 35
+        ? 0
+        : keyboardHeight,
+  };
+
   const _buttonsContainerStyle: ViewStyle = {
     ...styles.buttonsContainer,
     borderTopWidth: isExtensionVisible ? 1 : 0,
@@ -262,7 +273,7 @@ export const EditorToolbar = ({
   };
 
   return (
-    <View style={{ ..._containerStyle, marginBottom: keyboardHeight }}>
+    <View style={_keyboardAdjustedStyle}>
       {_renderExtension()}
 
       {!isPreviewActive && (

--- a/src/components/markdownEditor/children/editorToolbar.tsx
+++ b/src/components/markdownEditor/children/editorToolbar.tsx
@@ -252,18 +252,13 @@ export const EditorToolbar = ({
     );
   };
 
-
   const _containerStyle: ViewStyle = isExtensionVisible
     ? styles.container
     : styles.shadowedContainer;
 
-
   const _keyboardAdjustedStyle = {
     ..._containerStyle,
-    marginBottom:
-      Platform.OS === 'android' && Platform.Version < 35
-        ? 0
-        : keyboardHeight,
+    marginBottom: Platform.OS === 'android' && Platform.Version < 35 ? 0 : keyboardHeight,
   };
 
   const _buttonsContainerStyle: ViewStyle = {

--- a/src/components/quickPostModal/quickPostModal.tsx
+++ b/src/components/quickPostModal/quickPostModal.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { QuickPostModalContent } from './quickPostModalContent';
 import styles from './quickPostModal.styles';
 import { SheetNames } from '../../navigation/sheets';
@@ -24,6 +24,9 @@ const QuickPostModal = ({ payload }: SheetProps<SheetNames.QUICK_POST>) => {
         containerStyle={styles.sheetContent}
         indicatorStyle={styles.sheetIndicator}
         defaultOverlayOpacity={0}
+        keyboardHandlerEnabled={
+          Platform.OS === 'android' && Platform.Version < 35 ? false : true
+        }
         onClose={_onClose}
       >
         <QuickPostModalContent

--- a/src/components/quickPostModal/quickPostModal.tsx
+++ b/src/components/quickPostModal/quickPostModal.tsx
@@ -24,9 +24,7 @@ const QuickPostModal = ({ payload }: SheetProps<SheetNames.QUICK_POST>) => {
         containerStyle={styles.sheetContent}
         indicatorStyle={styles.sheetIndicator}
         defaultOverlayOpacity={0}
-        keyboardHandlerEnabled={
-          Platform.OS === 'android' && Platform.Version < 35 ? false : true
-        }
+        keyboardHandlerEnabled={!(Platform.OS === 'android' && Platform.Version < 35)}
         onClose={_onClose}
       >
         <QuickPostModalContent


### PR DESCRIPTION
### What does this PR?
fixes keyboard to content offset bug being produced on api level below 35.

### Issue number
https://discord.com/channels/@me/920267778190086205/1400630683931512832

### Screenshots/Video
BEFORE
<img width="1458" height="662" alt="Screenshot 2025-08-05 at 19 00 11" src="https://github.com/user-attachments/assets/6b9a91dc-fa8f-419f-b8ad-0bcf0132f2c0" />
<img width="1456" height="660" alt="Screenshot 2025-08-05 at 18 59 18" src="https://github.com/user-attachments/assets/575f30c6-6c09-45aa-bb65-a55ba63fba26" />


AFTER
<img width="1455" height="705" alt="Screenshot 2025-08-05 at 19 00 32" src="https://github.com/user-attachments/assets/650dddf5-22ff-437d-87ce-2132bfa14aea" />
<img width="1450" height="664" alt="Screenshot 2025-08-05 at 18 58 41" src="https://github.com/user-attachments/assets/32a1fc62-660a-4f68-977f-3619595d6187" />


