### PR TITLE
patched render-html for defaultProps replacement

### DIFF
--- a/patches/react-native-render-html+6.3.4.patch
+++ b/patches/react-native-render-html+6.3.4.patch
@@ -1,0 +1,179 @@
+diff --git a/node_modules/react-native-render-html/src/TChildrenRenderer.tsx b/node_modules/react-native-render-html/src/TChildrenRenderer.tsx
+index 618a592..fc89a54 100644
+--- a/node_modules/react-native-render-html/src/TChildrenRenderer.tsx
++++ b/node_modules/react-native-render-html/src/TChildrenRenderer.tsx
+@@ -2,23 +2,22 @@ import { FunctionComponent } from 'react';
+ import { TChildrenRendererProps } from './shared-types';
+ import renderChildren from './renderChildren';
+ 
+-/**
+- * A component to render collections of tnodes.
+- * Especially useful when used with {@link useTNodeChildrenProps}.
+- */
+-const TChildrenRenderer: FunctionComponent<TChildrenRendererProps> =
+-  renderChildren.bind(null);
+ 
+ export const tchildrenRendererDefaultProps: Pick<
+-  TChildrenRendererProps,
+-  'propsForChildren'
++    TChildrenRendererProps,
++    'propsForChildren'
+ > = {
+   propsForChildren: {}
+ };
+ 
+ /**
+- * @ignore
++ * A component to render collections of tnodes.
++ * Especially useful when used with {@link useTNodeChildrenProps}.
+  */
+-TChildrenRenderer.defaultProps = tchildrenRendererDefaultProps;
++// const TChildrenRenderer: FunctionComponent<TChildrenRendererProps> =
++//   renderChildren.bind(null);
++const TChildrenRenderer: FunctionComponent<TChildrenRendererProps> = (props) =>
++    renderChildren({ ...tchildrenRendererDefaultProps, ...props });
++
+ 
+ export default TChildrenRenderer;
+diff --git a/node_modules/react-native-render-html/src/TNodeChildrenRenderer.tsx b/node_modules/react-native-render-html/src/TNodeChildrenRenderer.tsx
+index bf5aef6..fa1e5e2 100644
+--- a/node_modules/react-native-render-html/src/TNodeChildrenRenderer.tsx
++++ b/node_modules/react-native-render-html/src/TNodeChildrenRenderer.tsx
+@@ -61,8 +61,10 @@ export function useTNodeChildrenProps({
+  * A component to render all children of a {@link TNode}.
+  */
+ function TNodeChildrenRenderer(
+-  props: TNodeChildrenRendererProps
++    propsInp: TNodeChildrenRendererProps
+ ): ReactElement {
++  const props = {  ...tchildrenRendererDefaultProps, ...propsInp };
++
+   if (props.tnode.type === 'text') {
+     // see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20544
+     return props.tnode.data as unknown as ReactElement;
+@@ -73,9 +75,4 @@ function TNodeChildrenRenderer(
+   return renderChildren(useTNodeChildrenProps(props));
+ }
+ 
+-/**
+- * @ignore
+- */
+-TNodeChildrenRenderer.defaultProps = tchildrenRendererDefaultProps;
+-
+ export default TNodeChildrenRenderer;
+diff --git a/node_modules/react-native-render-html/src/TNodeRenderer.tsx b/node_modules/react-native-render-html/src/TNodeRenderer.tsx
+index d32140f..66523eb 100644
+--- a/node_modules/react-native-render-html/src/TNodeRenderer.tsx
++++ b/node_modules/react-native-render-html/src/TNodeRenderer.tsx
+@@ -38,12 +38,20 @@ function isGhostTNode(tnode: TNode) {
+   );
+ }
+ 
++const defaultProps: Required<Pick<TNodeRendererProps<any>, 'propsFromParent'>> =
++    {
++      propsFromParent: {
++        collapsedMarginTop: null
++      }
++    };
++
+ /**
+  * A component to render any {@link TNode}.
+  */
+ const TNodeRenderer = memo(function MemoizedTNodeRenderer(
+-  props: TNodeRendererProps<any>
++  propsInp: TNodeRendererProps<any>
+ ): ReactElement | null {
++  const props = {  ...defaultProps, ...propsInp };
+   const { tnode } = props;
+   const sharedProps = useSharedProps();
+   const renderRegistry = useRendererRegistry();
+@@ -120,15 +128,6 @@ const TNodeRenderer = memo(function MemoizedTNodeRenderer(
+     : React.createElement(Renderer as any, assembledProps);
+ });
+ 
+-const defaultProps: Required<Pick<TNodeRendererProps<any>, 'propsFromParent'>> =
+-  {
+-    propsFromParent: {
+-      collapsedMarginTop: null
+-    }
+-  };
+-
+-// @ts-expect-error default props must be defined
+-TNodeRenderer.defaultProps = defaultProps;
+ 
+ export {
+   TDefaultBlockRenderer,
+diff --git a/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx b/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx
+index 95b60df..667bf3b 100644
+--- a/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx
++++ b/node_modules/react-native-render-html/src/TRenderEngineProvider.tsx
+@@ -95,10 +95,8 @@ export function useAmbientTRenderEngine() {
+  *
+  * @param props - Pass engine config here.
+  */
+-export default function TRenderEngineProvider({
+-  children,
+-  ...config
+-}: PropsWithChildren<TRenderEngineConfig>): ReactElement {
++export default function TRenderEngineProvider(props: PropsWithChildren<TRenderEngineConfig>): ReactElement {
++  const { children, ...config } = { ...defaultTRenderEngineProviderProps, ...props };
+   const engine = useTRenderEngine(config);
+   return (
+     <TRenderEngineContext.Provider value={engine}>
+@@ -107,11 +105,6 @@ export default function TRenderEngineProvider({
+   );
+ }
+ 
+-/**
+- * @ignore
+- */
+-TRenderEngineProvider.defaultProps = defaultTRenderEngineProviderProps;
+-
+ /**
+  * @ignore
+  */
+diff --git a/node_modules/react-native-render-html/src/elements/IMGElement.tsx b/node_modules/react-native-render-html/src/elements/IMGElement.tsx
+index 573e7c1..f8f3c28 100644
+--- a/node_modules/react-native-render-html/src/elements/IMGElement.tsx
++++ b/node_modules/react-native-render-html/src/elements/IMGElement.tsx
+@@ -14,6 +14,14 @@ function identity(arg: any) {
+   return arg;
+ }
+ 
++
++const defaultProps = {
++  enableExperimentalPercentWidth: false,
++  computeMaxWidth: identity,
++  imagesInitialDimensions: defaultImageInitialDimensions,
++  style: {}
++};
++
+ /**
+  * A component to render images based on an internal loading state.
+  *
+@@ -23,7 +31,9 @@ function identity(arg: any) {
+  * {@link IMGElementContentSuccess}, {@link IMGElementContentLoading}
+  * and {@link IMGElementContentError} for customization.
+  */
+-function IMGElement(props: IMGElementProps): ReactElement {
++
++function IMGElement(propsInp: IMGElementProps): ReactElement {
++  const props = { ...defaultProps, ...propsInp };
+   const state = useIMGElementState(props);
+   let content: ReactNode;
+   if (state.type === 'success') {
+@@ -72,14 +82,4 @@ const propTypes: Record<keyof IMGElementProps, any> = {
+  */
+ IMGElement.propTypes = propTypes;
+ 
+-/**
+- * @ignore
+- */
+-IMGElement.defaultProps = {
+-  enableExperimentalPercentWidth: false,
+-  computeMaxWidth: identity,
+-  imagesInitialDimensions: defaultImageInitialDimensions,
+-  style: {}
+-};
+-
+ export default IMGElement;


### PR DESCRIPTION
### What does this PR?
Render html is still using older defaultProps approach that has been deprecated in react-native, this patch fixes the bold and italic formats related issues caused by it.

### Screenshots/Video
<img width="272" height="610" alt="Screenshot 2025-08-25 at 16 14 46" src="https://github.com/user-attachments/assets/6276eaee-67f7-4979-ab54-86ebad87e932" />
