### PR TITLE
gh run concurrency handler

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - development
 
+concurrency:
+  group: android-build
+  cancel-in-progress: true
+
 jobs:
   android-build:
     name: Android Build
@@ -27,9 +31,7 @@ jobs:
     steps:
       - name: Show host machine information
         run: uname -a
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-
+        
       - name: Checkout PR head or development branch
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - development
 
+concurrency:
+  group: ios-build
+  cancel-in-progress: true
+
 jobs:
   ios-build:
     name: iOS Build
@@ -32,10 +36,6 @@ jobs:
         run: |
           uname -a
           xcodebuild -showsdks
-
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
-
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### What does this PR?
Apparently gh actions offer in built concurrency handler that manages runs based on of group ids. removed cancel action in favour of in-built concurrency handler

