### PR TITLE
Nt/optimise feed - iteration 1

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '16.4'
 
       - name: Show host machine information
         run: |

--- a/src/components/header/view/headerStyles.ts
+++ b/src/components/header/view/headerStyles.ts
@@ -5,7 +5,6 @@ export default EStyleSheet.create({
     flexDirection: 'row',
     width: '100%',
     backgroundColor: '$primaryBackgroundColor',
-    paddingTop: 8,
     paddingBottom: 4,
   },
   containerReverse: {

--- a/src/components/header/view/headerStyles.ts
+++ b/src/components/header/view/headerStyles.ts
@@ -6,7 +6,7 @@ export default EStyleSheet.create({
     width: '100%',
     backgroundColor: '$primaryBackgroundColor',
     paddingTop: 8,
-    paddingBottom: 12,
+    paddingBottom: 4,
   },
   containerReverse: {
     justifyContent: 'space-between',

--- a/src/components/postCard/children/postCardContent.tsx
+++ b/src/components/postCard/children/postCardContent.tsx
@@ -9,12 +9,12 @@ import { proxifyImageSrc } from '@ecency/render-helper';
 
 // Styles
 import { Image as ExpoImage } from 'expo-image';
+import { useLayoutState } from '@shopify/flash-list';
 import styles from '../styles/postCard.styles';
 import { PostCardActionIds } from '../container/postCard';
 import ROUTES from '../../../constants/routeNames';
 import { ContentType } from '../../../providers/hive/hive.types';
 import { isCommunity } from '../../../utils/communityValidation';
-import { useLayoutState } from '@shopify/flash-list';
 
 const DEFAULT_IMAGE =
   'https://images.ecency.com/DQmT8R33geccEjJfzZEdsRHpP3VE8pu3peRCnQa1qukU4KR/no_image_3x.png';
@@ -28,12 +28,7 @@ interface Props {
   handleCardInteraction: (id: PostCardActionIds, payload?: any) => void;
 }
 
-export const PostCardContent = ({
-  content,
-  isHideImage,
-  nsfw,
-  handleCardInteraction,
-}: Props) => {
+export const PostCardContent = ({ content, isHideImage, nsfw, handleCardInteraction }: Props) => {
   const intl = useIntl();
   const dim = useWindowDimensions();
   const imgRef = useRef<ExpoImage>(null);
@@ -41,7 +36,7 @@ export const PostCardContent = ({
 
   const imageRatio = content?.thumbRatio;
   const imgWidth = dim.width - 18;
-  const [imgHeight, setImgHeight] = useLayoutState(imageRatio ? imgWidth / imageRatio : 300)
+  const [imgHeight, setImgHeight] = useLayoutState(imageRatio ? imgWidth / imageRatio : 300);
   // const [autoplay, setAutoplay] = useState(false);
   // const [isAnimated, setIsAnimated] = useState(false);
 

--- a/src/components/postCard/children/postCardContent.tsx
+++ b/src/components/postCard/children/postCardContent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { TouchableOpacity, Text, View, useWindowDimensions } from 'react-native';
 // import { InView } from 'react-native-intersection-observer';
 // Utils
@@ -14,6 +14,7 @@ import { PostCardActionIds } from '../container/postCard';
 import ROUTES from '../../../constants/routeNames';
 import { ContentType } from '../../../providers/hive/hive.types';
 import { isCommunity } from '../../../utils/communityValidation';
+import { useLayoutState } from '@shopify/flash-list';
 
 const DEFAULT_IMAGE =
   'https://images.ecency.com/DQmT8R33geccEjJfzZEdsRHpP3VE8pu3peRCnQa1qukU4KR/no_image_3x.png';
@@ -23,18 +24,14 @@ const NSFW_IMAGE =
 interface Props {
   content: any;
   isHideImage: boolean;
-  imageRatio: number;
   nsfw: string;
-  setImageRatio: (postPath: string, height: number) => void;
   handleCardInteraction: (id: PostCardActionIds, payload?: any) => void;
 }
 
 export const PostCardContent = ({
   content,
   isHideImage,
-  imageRatio,
   nsfw,
-  setImageRatio,
   handleCardInteraction,
 }: Props) => {
   const intl = useIntl();
@@ -42,13 +39,14 @@ export const PostCardContent = ({
   const imgRef = useRef<ExpoImage>(null);
   // const isInViewRef = useRef(false);
 
+  const imageRatio = content?.thumbRatio;
   const imgWidth = dim.width - 18;
-  const [calcImgHeight, setCalcImgHeight] = useState(imageRatio ? imgWidth / imageRatio : 300);
+  const [imgHeight, setImgHeight] = useLayoutState(imageRatio ? imgWidth / imageRatio : 300)
   // const [autoplay, setAutoplay] = useState(false);
   // const [isAnimated, setIsAnimated] = useState(false);
 
   const resizeMode = useMemo(() => {
-    return calcImgHeight < dim.height ? 'contain' : 'cover';
+    return imgHeight < dim.height ? 'contain' : 'cover';
   }, [dim.height]);
 
   // featured text can be used to add more labels in future by just inserting text as array item
@@ -126,7 +124,7 @@ export const PostCardContent = ({
                 styles.thumbnail,
                 {
                   width: imgWidth,
-                  height: Math.min(calcImgHeight, dim.height),
+                  height: Math.min(imgHeight, dim.height),
                 },
               ]}
               contentFit={resizeMode}
@@ -140,8 +138,8 @@ export const PostCardContent = ({
                 if (!imageRatio) {
                   const _imgRatio = evt.source.width / evt.source.height;
                   const height = imgWidth / _imgRatio;
-                  setCalcImgHeight(height);
-                  setImageRatio(content.author + content.permlink, _imgRatio);
+                  setImgHeight(height);
+                  // setImageRatio(content.author + content.permlink, _imgRatio);
                 }
               }}
             />

--- a/src/components/postCard/container/postCard.tsx
+++ b/src/components/postCard/container/postCard.tsx
@@ -22,14 +22,7 @@ export enum PostCardActionIds {
   NAVIGATE = 'NAVIGATE',
 }
 
-const PostCard = ({
-  intl,
-  content,
-  isHideImage,
-  nsfw,
-  pageType,
-  handleCardInteraction,
-}) => {
+const PostCard = ({ intl, content, isHideImage, nsfw, pageType, handleCardInteraction }) => {
   return (
     <View style={styles.post}>
       <PostCardHeader

--- a/src/components/postCard/container/postCard.tsx
+++ b/src/components/postCard/container/postCard.tsx
@@ -27,9 +27,7 @@ const PostCard = ({
   content,
   isHideImage,
   nsfw,
-  imageRatio,
   pageType,
-  setImageRatio,
   handleCardInteraction,
 }) => {
   return (
@@ -45,8 +43,6 @@ const PostCard = ({
         content={content}
         isHideImage={isHideImage}
         nsfw={nsfw}
-        imageRatio={imageRatio}
-        setImageRatio={setImageRatio}
         handleCardInteraction={handleCardInteraction}
       />
       <PostCardActionsPanel content={content} handleCardInteraction={handleCardInteraction} />

--- a/src/components/postsList/container/postsListContainer.tsx
+++ b/src/components/postsList/container/postsListContainer.tsx
@@ -2,7 +2,6 @@ import React, {
   forwardRef,
   useRef,
   useImperativeHandle,
-  useState,
   useEffect,
   Fragment,
   useMemo,
@@ -243,7 +242,7 @@ const postsListContainer = (
         ItemSeparatorComponent={_renderSeparator}
         estimatedItemSize={609}
         windowSize={8}
-        extraData= {votesCache}
+        extraData={votesCache}
         onEndReached={_onEndReached}
         onMomentumScrollBegin={() => {
           _onEndReachedCalledDuringMomentum = false;

--- a/src/components/postsList/container/postsListContainer.tsx
+++ b/src/components/postsList/container/postsListContainer.tsx
@@ -76,7 +76,7 @@ const postsListContainer = (
     return isFeedScreen ? state.posts.feedScrollPosition : state.posts.otherScrollPosition;
   });
 
-  const [imageRatios, setImageRatios] = useState(new Map<string, number>());
+  // const [imageRatios, setImageRatios] = useState(new Map<string, number>());
 
   const data = useMemo(() => {
     let _data = posts || cachedPosts;
@@ -134,11 +134,11 @@ const postsListContainer = (
     });
   }, [scrollPosition]);
 
-  const _setImageRatioInMap = (mapKey: string, height: number) => {
-    if (mapKey && height) {
-      setImageRatios(imageRatios.set(mapKey, height));
-    }
-  };
+  // const _setImageRatioInMap = (mapKey: string, height: number) => {
+  //   if (mapKey && height) {
+  //     setImageRatios(imageRatios.set(mapKey, height));
+  //   }
+  // };
 
   const _renderFooter = () => {
     if (isLoading && !isRefreshing) {
@@ -214,11 +214,6 @@ const postsListContainer = (
   const _renderSeparator = () => <Separator style={styles.separator} />;
 
   const _renderItem = ({ item }: { item: any }) => {
-    // get image height from cache if available
-    const localId = item.author + item.permlink;
-    const imgRatio = item.thumbRatio || imageRatios.get(localId);
-
-    //   e.push(
     return (
       <PostCard
         intl={intl}
@@ -227,8 +222,6 @@ const postsListContainer = (
         pageType={pageType}
         isHideImage={isHideImages}
         nsfw={nsfw}
-        imageRatio={imgRatio}
-        setImageRatio={_setImageRatioInMap}
         handleCardInteraction={(id: PostCardActionIds, payload: any, onCallback) =>
           _handleCardInteraction(id, payload, item, onCallback)
         }
@@ -250,7 +243,7 @@ const postsListContainer = (
         ItemSeparatorComponent={_renderSeparator}
         estimatedItemSize={609}
         windowSize={8}
-        extraData={[imageRatios, votesCache]}
+        extraData= {votesCache}
         onEndReached={_onEndReached}
         onMomentumScrollBegin={() => {
           _onEndReachedCalledDuringMomentum = false;

--- a/src/components/profile/children/commentsTabContent.tsx
+++ b/src/components/profile/children/commentsTabContent.tsx
@@ -35,8 +35,9 @@ const CommentsTabContent = ({
   const [noMore, setNoMore] = useState(false);
 
   useEffect(() => {
+    console.log('selected user update', selectedUser);
     if (selectedUser) {
-      _fetchData();
+      _fetchData({ refresh: true });
     }
   }, [selectedUser]);
 

--- a/src/components/tabbedPosts/container/tabbedPosts.tsx
+++ b/src/components/tabbedPosts/container/tabbedPosts.tsx
@@ -2,11 +2,11 @@ import React, { useState } from 'react';
 import { TabView, TabBarProps } from 'react-native-tab-view';
 import { useWindowDimensions, View } from 'react-native';
 import { useIntl } from 'react-intl';
+import { Image } from 'expo-image';
 import { TabbedPostsProps } from '../types/tabbedPosts.types';
 import { FeedTabBar } from '../view/feedTabBar';
 import PostsTabContent from '../view/postsTabContent';
 import { Tag } from '../..';
-import { Image } from 'expo-image';
 
 export const TabbedPosts = ({
   tabFilters,
@@ -59,11 +59,10 @@ export const TabbedPosts = ({
     />
   );
 
-
-  const _setIndex = (i:number) => {
+  const _setIndex = (i: number) => {
     Image.clearMemoryCache();
-    setIndex(i)
-  }
+    setIndex(i);
+  };
 
   // Dynamically create scenes for each tab
   const renderScene = ({ route }) => {

--- a/src/components/tabbedPosts/container/tabbedPosts.tsx
+++ b/src/components/tabbedPosts/container/tabbedPosts.tsx
@@ -6,6 +6,7 @@ import { TabbedPostsProps } from '../types/tabbedPosts.types';
 import { FeedTabBar } from '../view/feedTabBar';
 import PostsTabContent from '../view/postsTabContent';
 import { Tag } from '../..';
+import { Image } from 'expo-image';
 
 export const TabbedPosts = ({
   tabFilters,
@@ -58,6 +59,12 @@ export const TabbedPosts = ({
     />
   );
 
+
+  const _setIndex = (i:number) => {
+    Image.clearMemoryCache();
+    setIndex(i)
+  }
+
   // Dynamically create scenes for each tab
   const renderScene = ({ route }) => {
     if (tabContentOverrides && tabContentOverrides.has(index)) {
@@ -87,7 +94,7 @@ export const TabbedPosts = ({
         renderTabBar={_renderTabBar}
         navigationState={{ index, routes }}
         renderScene={renderScene}
-        onIndexChange={setIndex}
+        onIndexChange={_setIndex}
         commonOptions={{
           label: _renderTabLabel,
         }}

--- a/src/screens/feed/screen/feedScreen.tsx
+++ b/src/screens/feed/screen/feedScreen.tsx
@@ -69,7 +69,7 @@ const FeedScreen = () => {
       feedFilters.indexOf('comments') >= 0
         ? new Map([[feedFilters.indexOf('comments'), _contentComentsTab('comments')]])
         : undefined,
-    [feedFilters],
+    [feedFilters, currentAccount],
   );
 
   return (

--- a/src/screens/wallet/screen/walletScreenStyles.ts
+++ b/src/screens/wallet/screen/walletScreenStyles.ts
@@ -18,5 +18,6 @@ export default EStyleSheet.create({
   listWrapper: {
     backgroundColor: '$primaryBackgroundColor',
     flex: 1,
+    paddingTop:8,
   },
 });

--- a/src/screens/waves/screen/wavesScreen.tsx
+++ b/src/screens/waves/screen/wavesScreen.tsx
@@ -140,7 +140,7 @@ const WavesScreen = ({ route }) => {
     <View style={styles.container}>
       <Header />
 
-      <View style={{ flex: 1 }}>
+      <View style={styles.contentContainer}>
         <Comments
           postType={PostTypes.WAVE}
           comments={_data}

--- a/src/screens/waves/styles/wavesScreen.styles.ts
+++ b/src/screens/waves/styles/wavesScreen.styles.ts
@@ -6,4 +6,8 @@ export default EStyleSheet.create({
     flex: 1,
     backgroundColor: '$primaryBackgroundColor',
   } as ViewStyle,
+  contentContainer: {
+    flex: 1, 
+    paddingTop: 8
+  } as ViewStyle
 });


### PR DESCRIPTION
### What does this PR?
Started with testing feed screen with single flatlist for every filter but apparently the result was same as with using separate tabs with separate flatlist, however I did notice some abnormalities that I am working on next

- clearing image memory cache on tab change (not storage)
I expected flatlist and tabs to manage this internally, but apparently they do not and keep hold to the images cache even if the tab is not used for a while. This small change clears the memory cache, but not clear them from temp storage, means only we can more memory without having any hit on the user experience, or atleast it's not obvious.

- no longer managing image ratio externally
previously we have external maps to manage image ratios for posts not have ratios stored in metadata. this was done so to avoid reinitiated state every time flat list recycles the view. now with new useLayoutState hook, the list manages it's own state for items internally even if the view is recycled, and list will have to listen for changes in one less extraData

Other minor changes
- fixed My Comments section not updating on profile change
- fine tuned feed header paddings a bit
- fixe failing ios CI builds


### Issue number

### Screenshots/Video
BEFORE
<img width="1253" height="766" alt="Screenshot 2025-09-12 at 11 02 33" src="https://github.com/user-attachments/assets/a090d8a5-00db-43be-a338-93b4eb499dc8" />

AFTER
<img width="1284" height="778" alt="Screenshot 2025-09-12 at 20 52 54" src="https://github.com/user-attachments/assets/717f24ac-a4be-4f87-812f-b91b9b283721" />