### PR TITLE
Nt/waves UI tweaks

### DIFF
--- a/src/components/quickPostModal/quickPostModal.styles.ts
+++ b/src/components/quickPostModal/quickPostModal.styles.ts
@@ -106,7 +106,7 @@ export default EStyleSheet.create({
   },
   name: {
     marginLeft: 4,
-    color: '$primaryDarkGray',
+    color: '$primaryBlack',
   },
   titleContainer: {
     paddingHorizontal: 16,

--- a/src/components/quickPostModal/quickPostModal.styles.ts
+++ b/src/components/quickPostModal/quickPostModal.styles.ts
@@ -73,7 +73,7 @@ export default EStyleSheet.create({
     paddingHorizontal: 16,
   },
   commentBtn: {
-    width: 100,
+    minWidth: 100,
     height: 40,
     alignItems: 'center',
     justifyContent: 'center',

--- a/src/components/quickPostModal/quickPostModalContent.tsx
+++ b/src/components/quickPostModal/quickPostModalContent.tsx
@@ -84,9 +84,10 @@ export const QuickPostModalContent = forwardRef(
     const headerText =
       mode === 'wave'
         ? intl.formatMessage(
-          { id: 'quick_reply.summary_wave' },
-          { host: intl.formatMessage({ id: 'quick_reply.host_waves' }) }  // TODO: update based on selected host
-        ) : selectedPost && (selectedPost.summary || postBodySummary(selectedPost, 150, Platform.OS));
+            { id: 'quick_reply.summary_wave' },
+            { host: intl.formatMessage({ id: 'quick_reply.host_waves' }) }, // TODO: update based on selected host
+          )
+        : selectedPost && (selectedPost.summary || postBodySummary(selectedPost, 150, Platform.OS));
 
     const draftId =
       mode === 'wave'

--- a/src/components/quickPostModal/quickPostModalContent.tsx
+++ b/src/components/quickPostModal/quickPostModalContent.tsx
@@ -83,8 +83,10 @@ export const QuickPostModalContent = forwardRef(
 
     const headerText =
       mode === 'wave'
-        ? intl.formatMessage({ id: 'quick_reply.summary_wave' }, { host: 'ecency.waves' }) // TODO: update based on selected host
-        : selectedPost && (selectedPost.summary || postBodySummary(selectedPost, 150, Platform.OS));
+        ? intl.formatMessage(
+          { id: 'quick_reply.summary_wave' },
+          { host: intl.formatMessage({ id: 'quick_reply.host_waves' }) }  // TODO: update based on selected host
+        ) : selectedPost && (selectedPost.summary || postBodySummary(selectedPost, 150, Platform.OS));
 
     const draftId =
       mode === 'wave'

--- a/src/components/uploadsGalleryModal/children/uploadsGalleryModalStyles.ts
+++ b/src/components/uploadsGalleryModal/children/uploadsGalleryModalStyles.ts
@@ -30,7 +30,7 @@ export default EStyleSheet.create({
     height: THUMB_SIZE,
     width: THUMB_SIZE,
     borderRadius: 16,
-    backgroundColor: '$primaryLightGray',
+    backgroundColor: '$primaryLightBackground',
   } as ImageStyle,
 
   gridMediaItem: {
@@ -39,7 +39,7 @@ export default EStyleSheet.create({
     width: GRID_THUMB_SIZE,
     marginVertical: 8,
     borderRadius: 16,
-    backgroundColor: '$primaryLightGray',
+    backgroundColor: '$primaryLightBackground',
   } as ImageStyle,
 
   inputContainer: {

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1149,7 +1149,7 @@
   "quick_reply": {
     "placeholder": "Add a comment...",
     "placeholder_wave": "What's happening?",
-    "summary_wave": "Published in {host}",
+    "summary_wave": "Publishing in {host}",
     "host_waves":"Waves",
     "comment": "Comment",
     "reply": "REPLY",

--- a/src/config/locales/en-US.json
+++ b/src/config/locales/en-US.json
@@ -1149,7 +1149,8 @@
   "quick_reply": {
     "placeholder": "Add a comment...",
     "placeholder_wave": "What's happening?",
-    "summary_wave": "Will be published in: {host}",
+    "summary_wave": "Published in {host}",
+    "host_waves":"Waves",
     "comment": "Comment",
     "reply": "REPLY",
     "publish": "PUBLISH",

--- a/src/screens/waves/styles/children.styles.ts
+++ b/src/screens/waves/styles/children.styles.ts
@@ -11,7 +11,6 @@ export default EStyleSheet.create({
   } as ViewStyle,
   headerTitle: {
     color: '$primaryDarkText',
-    marginTop: 16,
     fontSize: 24,
     fontWeight: '200',
   } as TextStyle,


### PR DESCRIPTION
### What does this PR?

Editor Modal
- allow auto button width
- changed header label
- darken username text color
- updated placeholder color to be more subtle

Waves Screen
- Removed top header margin


### Screenshots/Video
<img width="271" height="580" alt="Screenshot 2025-09-18 at 10 59 45" src="https://github.com/user-attachments/assets/7e8bbcc0-4823-4a58-aee5-27b362321a71" />
<img width="267" height="578" alt="Screenshot 2025-09-18 at 11 09 49" src="https://github.com/user-attachments/assets/42b5afaa-b432-4d80-a734-8d1d501ab9e2" />
<img width="266" height="579" alt="Screenshot 2025-09-18 at 11 10 24" src="https://github.com/user-attachments/assets/71098240-e188-46ff-a4bb-3272c2ddb3b8" />
