### PR TITLE
normalising ececny://sign/ to hive-uri

### DIFF
--- a/src/utils/hive-uri.ts
+++ b/src/utils/hive-uri.ts
@@ -11,7 +11,7 @@ import * as operationsData from './operations.json';
 export const normalizeHiveUri = (uri: string) => {
   const trimUri = uri.trim();
   const lowerCaseUri = trimUri.toLowerCase();
-  if (lowerCaseUri.startsWith('ecency://sign/transfer')) {
+  if (lowerCaseUri.startsWith('ecency://sign/')) {
     return `hive://${trimUri.slice('ecency://'.length)}`;
   }
 


### PR DESCRIPTION
### What does this PR?
Updated normalise method to support `ececny://sign/` conversion to `hive://sign/`

This adds support for not only` ecency://sign/op` but also `sign/tx`, `sign/msg` and `sign/<operations>`, as supported by hive-uri mentioned under **Actions** here https://www.npmjs.com/package/hive-uri

### Screenshots/Video
https://github.com/user-attachments/assets/369a0caf-76ea-4b89-a96c-27ff6dda8949
