### PR TITLE
avoid expo based project versioning

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,7 +102,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode versionMajor * 10000 + versionMinor * 100 + versionPatch
-        versionName "3.3.5"
+        versionName "3.3.6"
         resValue "string", "build_config_package", "app.esteem.mobile.android"
         multiDexEnabled true
         // react-native-image-crop-picker

--- a/app.json
+++ b/app.json
@@ -11,13 +11,6 @@
           "organization": "ecency"
         }
       ]
-    ],
-    "version": "3.3.5",
-    "android": {
-      "versionCode": 1
-    },
-    "ios": {
-      "buildNumber": "1"
-    }
+    ]
   }
 }

--- a/ios/Ecency.xcodeproj/project.pbxproj
+++ b/ios/Ecency.xcodeproj/project.pbxproj
@@ -1450,7 +1450,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;
@@ -1496,7 +1496,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;
@@ -1537,7 +1537,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;
@@ -1620,7 +1620,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 75B6RXTKGT;

--- a/ios/Ecency/Info.plist
+++ b/ios/Ecency/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.5</string>
+	<string>3.3.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -56,10 +56,10 @@
 		<string>superhuman</string>
 		<string>yandexmail</string>
 		<string>fastmail</string>
-                <string>protonmail</string>
-                <string>szn-email</string>
-                <string>waves</string>
-        </array>
+		<string>protonmail</string>
+		<string>szn-email</string>
+		<string>waves</string>
+	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0.0</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ios/EcencyTests/Info.plist
+++ b/ios/EcencyTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.4</string>
+	<string>3.3.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 </dict>
 </plist>

--- a/ios/eshare/Info.plist
+++ b/ios/eshare/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.4</string>
+	<string>3.3.6</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "version": "./version-ios.sh",
-    "postversion": "react-native-version --never-amend --legacy",
+    "postversion": "react-native-version --never-amend --legacy --skip-expo",
     "start": "react-native start",
     "android": "react-native run-android",
     "ios": "react-native run-ios",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecency",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "displayName": "Ecency",
   "private": true,
   "rnpm": {

--- a/patches/react-native-version+4.0.0.patch
+++ b/patches/react-native-version+4.0.0.patch
@@ -1,0 +1,52 @@
+diff --git a/node_modules/react-native-version/README.md b/node_modules/react-native-version/README.md
+index 1f3aa85..21ce3ff 100644
+--- a/node_modules/react-native-version/README.md
++++ b/node_modules/react-native-version/README.md
+@@ -72,6 +72,7 @@ $ react-native-version
+     -s, --set-build <number>     Set a build number. WARNING: Watch out when setting high values. This option follows Android's app versioning specifics - the value has to be an integer and cannot be greater than 2100000000. You cannot decrement this value after publishing to Google Play! More info at: https://developer.android.com/studio/publish/versioning.html#appversioning
+     --generate-build             Generate build number from the package version number. (e.g. build number for version 1.22.3 will be 1022003)
+     -t, --target <platforms>     Only version specified platforms, e.g. "--target android,ios".
++    -e, --skip-expo              Skip Expo versioning even if detected.
+     -h, --help                   output usage information
+ 
+ <!-- END cli -->
+diff --git a/node_modules/react-native-version/cli.js b/node_modules/react-native-version/cli.js
+index 15f4c32..678d5b5 100755
+--- a/node_modules/react-native-version/cli.js
++++ b/node_modules/react-native-version/cli.js
+@@ -53,6 +53,7 @@ program
+ 		'Only version specified platforms, e.g. "--target android,ios".',
+ 		list
+ 	)
++	.option("-e, --skip-expo", "Skip Expo versioning even if detected.")
+ 	.parse(process.argv);
+ 
+ rnv.version(program);
+diff --git a/node_modules/react-native-version/index.js b/node_modules/react-native-version/index.js
+index 345f3d4..de5e692 100644
+--- a/node_modules/react-native-version/index.js
++++ b/node_modules/react-native-version/index.js
+@@ -114,12 +114,12 @@ function getCFBundleShortVersionString(versionName) {
+  * @private
+  * @return {Boolean} true if the project is an Expo app
+  */
+-function isExpoProject(projPath) {
++function isExpoProject(projPath, programOpts) {
+ 	try {
+ 		let module = resolveFrom(projPath, "expo");
+ 		let appInfo = require(`${projPath}/app.json`);
+ 
+-		return !!(module && appInfo.expo);
++		return !!(!programOpts.skipExpo && module && appInfo.expo);
+ 	} catch (err) {
+ 		return false;
+ 	}
+@@ -183,7 +183,7 @@ function version(program, projectPath) {
+ 
+ 	var appJSON;
+ 	const appJSONPath = path.join(projPath, "app.json");
+-	const isExpoApp = isExpoProject(projPath);
++	const isExpoApp = isExpoProject(projPath, programOpts);
+ 
+ 	isExpoApp && log({ text: "Expo detected" }, programOpts.quiet);
+ 


### PR DESCRIPTION
### What does this PR?
skipped expo based project versioning as it was conflicting with our version bump flow.


### Screenshots/Video
<img width="675" height="448" alt="Screenshot 2025-09-25 at 11 42 11" src="https://github.com/user-attachments/assets/43d103ec-5475-4f79-8c96-561aa2cec08f" />
