### PR TITLE
removed third party deep link domains from android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -131,30 +131,7 @@
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="ecency" />
         </intent-filter>
-        <intent-filter android:label="Ecency">
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
-            <data android:scheme="https" android:host="esteem.app" />
-        </intent-filter>
-        <intent-filter android:label="Ecency">
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
-            <data android:scheme="https" android:host="hive.blog" />
-        </intent-filter>
-        <intent-filter android:label="Ecency">
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
-            <data android:scheme="https" android:host="peakd.com" />
-        </intent-filter>
-        <intent-filter android:label="Ecency">
-            <action android:name="android.intent.action.VIEW" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <category android:name="android.intent.category.BROWSABLE" />
-            <data android:scheme="https" android:host="leofinance.io" />
-        </intent-filter>
+
         <intent-filter android:label="Ecency">
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.DEFAULT" />
@@ -180,9 +157,6 @@
       <meta-data
           android:name="com.google.firebase.messaging.default_notification_icon"
           android:resource="@drawable/ic_notification" />
-      <!-- <meta-data
-          android:name="com.google.firebase.messaging.default_notification_color"
-          android:resource="@color/notification_icon" /> -->
       <meta-data
             tools:replace="android:value"
             android:name="google_analytics_adid_collection_enabled"


### PR DESCRIPTION
### What does this PR?
Since there is not hosted domain check document and most certainly these domains will not host verification document on their side, I have remove them from android manifest to atleast get rid of play store console errors.

### Issue number
fixes #2865 

### Screenshots/Video
<img width="1251" height="545" alt="Screenshot 2025-10-07 at 19 16 43" src="https://github.com/user-attachments/assets/34d87108-1b4e-473f-8e0e-0c177a03620e" />
